### PR TITLE
Add commit offsets patch

### DIFF
--- a/.github/workflows/check-format-and-test-cloudflare-workers.yml
+++ b/.github/workflows/check-format-and-test-cloudflare-workers.yml
@@ -28,3 +28,26 @@ jobs:
         with:
           cmd: prettier --check .
           dir: cloudflare-workers
+
+  test:
+    name: Test PR
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./cloudflare-workers
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        name: Set Node.js 20.x
+        with:
+          node-version: 20.x
+      - uses: borales/actions-yarn@v5
+        name: Run install
+        with:
+          cmd: install
+          dir: cloudflare-workers
+      - uses: borales/actions-yarn@v5
+        name: Run Tests
+        with:
+          cmd: test
+          dir: cloudflare-workers

--- a/cloudflare-workers/package.json
+++ b/cloudflare-workers/package.json
@@ -15,9 +15,9 @@
 	"devDependencies": {
 		"@cloudflare/vitest-pool-workers": "^0.4.5",
 		"@cloudflare/workers-types": "^4.20240712.0",
-		"prettier": "3.3.3",
+		"prettier": "^3.3.3",
 		"typescript": "^5.5.4",
-		"vitest": "2.0.5",
+		"vitest": "1.5.0",
 		"wrangler": "^3.72.0"
 	},
 	"packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e",

--- a/cloudflare-workers/package.json
+++ b/cloudflare-workers/package.json
@@ -16,9 +16,9 @@
 		"@cloudflare/vitest-pool-workers": "^0.4.5",
 		"@cloudflare/workers-types": "^4.20240712.0",
 		"prettier": "3.3.3",
-		"typescript": "^5.5.2",
-		"vitest": "1.5.0",
-		"wrangler": "^3.67.1"
+		"typescript": "^5.5.4",
+		"vitest": "2.0.5",
+		"wrangler": "^3.72.0"
 	},
 	"packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e",
 	"dependencies": {

--- a/cloudflare-workers/src/administration.ts
+++ b/cloudflare-workers/src/administration.ts
@@ -1,4 +1,4 @@
-import { getComment, getMeta, getPaths, setMeta, setPath, updateCommentOffsets } from './db';
+import { getComment, getMeta, getPaths, isPathExists, setMeta, setPath, updateCommentOffsets } from './db';
 import { ModifiedCommentBody } from './types';
 
 type Replacement = {
@@ -49,11 +49,11 @@ export async function renameComments(env: Env, oldPath: string, newPath: string)
 		throw new Error('The path you want to rename from and to are the same');
 	}
 
-	const paths = await getPaths(env);
-	if (!paths.includes(oldPath)) {
+	const [oldPathExists, newPathExists] = await isPathExists(env, oldPath, newPath);
+	if (!oldPathExists) {
 		return;
 	}
-	if (paths.includes(newPath)) {
+	if (newPathExists) {
 		throw new Error('The path you want to rename to already exists');
 	}
 
@@ -61,8 +61,7 @@ export async function renameComments(env: Env, oldPath: string, newPath: string)
 }
 
 export async function modifyComments(env: Env, path: string, diff: ModifiedCommentBody['diff']) {
-	const paths = await getPaths(env);
-	if (!paths.includes(path)) {
+	if (!(await isPathExists(env, path))) {
 		throw new Error('The path you want to modify does not exist');
 	}
 

--- a/cloudflare-workers/src/administration.ts
+++ b/cloudflare-workers/src/administration.ts
@@ -12,9 +12,10 @@ type Replacement = {
 	};
 };
 
-type OffsetDiff = {
-	len: number;
-	diff: number;
+type OffsetDelta = {
+	startDelta: number;
+	endDelta: number;
+	invaild?: boolean;
 };
 
 const encoder = new TextEncoder();
@@ -62,106 +63,63 @@ export async function modifyComments(env: Env, path: string, diff: ModifiedComme
 
 	const replacement: Replacement[] = [];
 
-	// Sort diff by i1
-	diff = diff.sort((a, b) => a.i1 - b.i1);
+	const offsets: Offset[] = (await getOffsets(env, path)).sort((a, b) => a.start - b.start);
 
-	function _calcDiff(
-		offsets: Offset[],
-		pseudoOffsetsDiffArr: {
-			beforeEverything: OffsetDiff;
-		},
-		offsetsDiffArr: OffsetDiff[],
-	) {
-		for (const { tag, i1, i2, j1, j2 } of diff) {
-			// console.log('In diff:', tag, i1, i2, j1, j2);
+	if (offsets.length === 0) {
+		return;
+	}
+
+	const offsetsDelta: OffsetDelta[] = Array.from({ length: offsets.length }, () => ({ startDelta: 0, endDelta: 0 }));
+
+	for (const { tag, i1, i2, j1, j2 } of diff) {
+		for (let i = 0; i < offsets.length; i++) {
+			const { start, end } = offsets[i];
+			const delta = offsetsDelta[i];
 			switch (tag) {
 				case 'insert': {
-					const offsetIdx = offsets.findIndex((offset: { start: number; end: number }) => offset.start <= i1 && offset.end >= i1);
-					// 插入点在某个区间内
-					if (offsetIdx >= 0) {
-						// 更改区间长度
-						const diff = offsetsDiffArr[offsetIdx];
-						// console.log('  插入点在某个区间内：', diff.len, j2 - j1); // checked
-						diff.len += j2 - j1;
+					const insertedLength = j2 - j1;
+					// 插入点在该区间前
+					if (i1 < start) {
+						delta.startDelta += insertedLength;
+						delta.endDelta += insertedLength;
 					}
-					// 插入点在任意区间外
-					else {
-						// 更改距离插入位置最近的前一个区间的差分
-						const diff = offsets.findIndex((offset: { start: number }) => offset.start > i1) - 1;
-						// console.log('  插入点在任意区间外：', diff, j2 - j1); // checked
-						// 如果插入位置在所有 offset 区间前
-						if (diff == -1) {
-							pseudoOffsetsDiffArr.beforeEverything.diff += j2 - j1;
-						} else if (diff >= 0) {
-							offsetsDiffArr[diff].diff += j2 - j1;
-						}
+					// 插入点在该区间内
+					else if (start <= i1 && i1 <= end) {
+						delta.endDelta += insertedLength;
 					}
+					// 插入点在该区间外不需要变动
 
 					break;
 				}
 
-				case 'replace':
-				case 'delete': {
-					// 如果该 diff 在所有 offset 区间前
-					if (i2 <= pseudoOffsetsDiffArr.beforeEverything.len + pseudoOffsetsDiffArr.beforeEverything.diff) {
-						// console.log('  该 diff 在所有 offset 区间前', i2 - i1 - (j2 - j1)); // checked
-						pseudoOffsetsDiffArr.beforeEverything.diff -= i2 - i1 - (j2 - j1);
-						break;
+				case 'delete':
+				case 'replace': {
+					// 替换点在该区间前
+					if (i2 < start) {
+						const deltaLength = j2 - j1 - (i2 - i1);
+						delta.startDelta += deltaLength;
+						delta.endDelta += deltaLength;
 					}
-
-					const offsetIdxs = offsets.map((_: any, idx: number) => idx);
-					offsetIdxs.unshift(-1);
-
-					for (const offsetIdx of offsetIdxs) {
-						const { start, end } = offsetIdx === -1 ? { start: 0, end: pseudoOffsetsDiffArr.beforeEverything.len } : offsets[offsetIdx];
-						const diff = offsetIdx === -1 ? pseudoOffsetsDiffArr.beforeEverything : offsetsDiffArr[offsetIdx];
-						// console.log('  offsetIdx:', offsetIdx, start, end, diff);
-
-						// 如果 diff 完全包含 offset
-						if (i1 <= start && i2 >= end) {
-							// console.log('  diff 完全包含 offset', diff); // checked
-							diff.len = 0;
-						}
-						// 如果 offset 完全包含 diff
-						else if (start <= i1 && end >= i2) {
-							// console.log('  offset 完全包含 diff', diff, diff.len - (i2 - i1 - (j2 - j1))); // checked
-							diff.len -= i2 - i1 - (j2 - j1);
-						}
-						// 如果 diff 左半边在 offset 内，右半边在 offset 外
-						else if (i1 >= start && i1 <= end) {
-							if (tag === 'delete') {
-								// console.log('  diff 左半边在 offset 内，右半边在 offset 外', diff, end - i1); // checked
-								diff.len -= end - i1;
-							}
-						}
-						// 如果 diff 右半边在 offset 内，左半边在 offset 外
-						else if (i2 >= start && i2 <= end) {
-							if (tag === 'delete') {
-								// console.log('  diff 右半边在 offset 内，左半边在 offset 外', diff, i2 - start); // checked
-								diff.len -= i2 - start;
-							}
-						}
+					// 替换点在该区间内
+					else if (i1 >= start && i2 <= end) {
+						const deltaLength = j2 - j1 - (i2 - i1);
+						delta.endDelta += deltaLength;
 					}
-
-					// 如果有 diff 跨多段 offset，那么直接删除多段 offset 的 diff
-					if (tag === 'replace') {
-						const cross = offsetIdxs
-							.map((offsetIdx) => ({
-								offset: offsetIdx === -1 ? { start: 0, end: pseudoOffsetsDiffArr.beforeEverything.len } : offsets[offsetIdx],
-								diff: offsetIdx === -1 ? pseudoOffsetsDiffArr.beforeEverything : offsetsDiffArr[offsetIdx],
-							}))
-							.filter((d) => (i1 >= d.offset.start && i1 <= d.offset.end) || (i2 >= d.offset.start && i2 <= d.offset.end));
-						if (cross.length > 1) {
-							let len = cross.reduce((acc, d) => acc + d.diff.len, 0);
-							// 跨段 diff 转 len 补偿
-							len += cross.slice(-1).reduce((acc, d) => acc + d.diff.diff, 0);
-							for (const d of cross) {
-								// console.log('  跨段 replace', d, diff);
-								d.diff.len = 0;
-							}
-							cross[0].diff.diff += len - (i2 - i1 - (j2 - j1));
-						}
+					// 替换点右半边在该区间内，左半边在该区间外
+					else if (i1 < start && i2 >= start && i2 <= end) {
+						const deltaLength = i1 - start; // 获取替换部分
+						delta.startDelta += deltaLength;
+						delta.endDelta += deltaLength - (i2 - start);
 					}
+					// 替换点右半边在该区间外，左半边在该区间内
+					else if (i2 > end && i1 >= start && i1 <= end) {
+						delta.endDelta += i1 - end;
+					}
+					// 替换点包括整个区间
+					else if (i1 < start && i2 > end) {
+						delta.invaild = true;
+					}
+					// 替换点在该区间后不需要变动
 
 					break;
 				}
@@ -169,93 +127,22 @@ export async function modifyComments(env: Env, path: string, diff: ModifiedComme
 		}
 	}
 
-	// Distinct offsets
-	const offsets = (await getOffsets(env, path)).sort((a, b) => a.start - b.start);
-
-	if (offsets.length === 0) {
-		return;
-	}
-
-	const pseudoOffsetsDiffArr = {
-		beforeEverything: {
-			len: 0,
-			diff: offsets[0].start,
-		},
-	};
-
-	// offsets diff array
-	const offsetsDiffArr = offsets.map((offset, idx, that) => ({
-		len: offset.end - offset.start,
-		diff: idx === that.length - 1 ? 0 : that[idx + 1].start - offset.end,
-	}));
-
-	const diffPseudoOffsetsDiffArr = {
-		beforeEverything: {
-			len: pseudoOffsetsDiffArr.beforeEverything.diff,
-			diff: 0,
-		},
-	};
-
-	let lastDiffOffsetEnd = diffPseudoOffsetsDiffArr.beforeEverything.len;
-	const diffOffsets = offsetsDiffArr.map((diff) => {
-		const offset = {
-			start: lastDiffOffsetEnd + diff.len,
-			end: lastDiffOffsetEnd + diff.len + diff.diff,
-		};
-		lastDiffOffsetEnd = offset.end;
-		return offset;
-	});
-
-	const diffOffsetsDiffArr = diffOffsets.map((offset, idx, that) => ({
-		len: offset.end - offset.start,
-		diff: idx === that.length - 1 ? 0 : that[idx + 1].start - offset.end,
-	}));
-
-	// console.log('Initialalize:', offsets, pseudoOffsetsDiffArr, offsetsDiffArr);
-	// 计算 offset 更改
-	_calcDiff(offsets, pseudoOffsetsDiffArr, offsetsDiffArr);
-	// console.log('Finalalize:', offsets, pseudoOffsetsDiffArr, offsetsDiffArr);
-
-	// console.log('Diff Initialalize:', diffOffsets, diffPseudoOffsetsDiffArr, diffOffsetsDiffArr);
-	// 计算 diff.diff 更改
-	_calcDiff(diffOffsets, diffPseudoOffsetsDiffArr, diffOffsetsDiffArr);
-	// 应用 diff.diff 更改到 offset
-	for (const [idx, diff] of diffOffsetsDiffArr.entries()) {
-		offsetsDiffArr[idx].diff += diff.len - (diffOffsets[idx].end - diffOffsets[idx].start);
-	}
-	pseudoOffsetsDiffArr.beforeEverything.diff += diffPseudoOffsetsDiffArr.beforeEverything.len - offsets[0].start;
-	// console.log('Diff Finalalize:', diffOffsets, diffPseudoOffsetsDiffArr, diffOffsetsDiffArr);
-
-	let lastOffset = {
-		start: 0,
-		end: pseudoOffsetsDiffArr.beforeEverything.len,
-	};
-	let lastDiff = {
-		len: 0,
-		diff: pseudoOffsetsDiffArr.beforeEverything.diff,
-	};
-	// console.log('Check (pseudo):', lastOffset, lastDiff);
-	for (const [idx, diff] of offsetsDiffArr.entries()) {
-		const offset = offsets[idx];
-		// console.log('Check:', offset, diff);
-
-		const from = {
-			start: offset.start,
-			end: offset.end,
-		};
-		const to = {
-			start: lastOffset.end + lastDiff.diff,
-			end: lastOffset.end + lastDiff.diff + diff.len,
-		};
-
-		if (diff.len === 0) {
-			replacement.push({ from });
-		} else {
-			replacement.push({ from, to });
-		}
-
-		lastOffset = to;
-		lastDiff = diff;
+	for (let i = 0; i < offsets.length; i++) {
+		const { start, end } = offsets[i];
+		const { startDelta, endDelta, invaild } = offsetsDelta[i];
+		replacement.push({
+			from: {
+				start: start,
+				end: end,
+			},
+			to:
+				invaild === true
+					? undefined
+					: {
+							start: start + startDelta,
+							end: end + endDelta,
+						},
+		});
 	}
 
 	await updateCommentOffsets(env, path, replacement);

--- a/cloudflare-workers/src/administration.ts
+++ b/cloudflare-workers/src/administration.ts
@@ -1,5 +1,5 @@
-import { getComment, getMeta, getPaths, isPathExists, setMeta, setPath, updateCommentOffsets } from './db';
-import { ModifiedCommentBody } from './types';
+import { getComment, getMeta, getOffsets, getPaths, isPathExists, setMeta, setPath, updateCommentOffsets } from './db';
+import { ModifiedCommentBody, Offset } from './types';
 
 type Replacement = {
 	from: {
@@ -10,11 +10,6 @@ type Replacement = {
 		start: number;
 		end: number;
 	};
-};
-
-type Offset = {
-	start: number;
-	end: number;
 };
 
 type OffsetDiff = {
@@ -175,11 +170,7 @@ export async function modifyComments(env: Env, path: string, diff: ModifiedComme
 	}
 
 	// Distinct offsets
-	const offsets = [
-		...new Map((await getComment(env, { path })).map((comment) => comment.offset).map((offset) => [offset.start, offset.end])).entries(),
-	]
-		.map(([start, end]) => ({ start, end }))
-		.sort((a, b) => a.start - b.start);
+	const offsets = (await getOffsets(env, path)).sort((a, b) => a.start - b.start);
 
 	if (offsets.length === 0) {
 		return;

--- a/cloudflare-workers/src/administration.ts
+++ b/cloudflare-workers/src/administration.ts
@@ -1,22 +1,6 @@
 import { getComment, getMeta, getOffsets, getPaths, isPathExists, setMeta, setPath, updateCommentOffsets } from './db';
 import { ModifiedCommentBody, Offset } from './types';
-
-type Replacement = {
-	from: {
-		start: number;
-		end: number;
-	};
-	to?: {
-		start: number;
-		end: number;
-	};
-};
-
-type OffsetDelta = {
-	startDelta: number;
-	endDelta: number;
-	invaild?: boolean;
-};
+import { calcOffsetModification } from './utils';
 
 const encoder = new TextEncoder();
 
@@ -61,89 +45,11 @@ export async function modifyComments(env: Env, path: string, diff: ModifiedComme
 		throw new Error('The path you want to modify does not exist');
 	}
 
-	const replacement: Replacement[] = [];
-
 	const offsets: Offset[] = (await getOffsets(env, path)).sort((a, b) => a.start - b.start);
 
 	if (offsets.length === 0) {
 		return;
 	}
 
-	const offsetsDelta: OffsetDelta[] = Array.from({ length: offsets.length }, () => ({ startDelta: 0, endDelta: 0 }));
-
-	for (const { tag, i1, i2, j1, j2 } of diff) {
-		for (let i = 0; i < offsets.length; i++) {
-			const { start, end } = offsets[i];
-			const delta = offsetsDelta[i];
-			switch (tag) {
-				case 'insert': {
-					const insertedLength = j2 - j1;
-					// 插入点在该区间前
-					if (i1 < start) {
-						delta.startDelta += insertedLength;
-						delta.endDelta += insertedLength;
-					}
-					// 插入点在该区间内
-					else if (start <= i1 && i1 <= end) {
-						delta.endDelta += insertedLength;
-					}
-					// 插入点在该区间外不需要变动
-
-					break;
-				}
-
-				case 'delete':
-				case 'replace': {
-					// 替换点在该区间前
-					if (i2 < start) {
-						const deltaLength = j2 - j1 - (i2 - i1);
-						delta.startDelta += deltaLength;
-						delta.endDelta += deltaLength;
-					}
-					// 替换点在该区间内
-					else if (i1 >= start && i2 <= end) {
-						const deltaLength = j2 - j1 - (i2 - i1);
-						delta.endDelta += deltaLength;
-					}
-					// 替换点右半边在该区间内，左半边在该区间外
-					else if (i1 < start && i2 >= start && i2 <= end) {
-						const deltaLength = i1 - start; // 获取替换部分
-						delta.startDelta += deltaLength;
-						delta.endDelta += deltaLength - (i2 - start);
-					}
-					// 替换点右半边在该区间外，左半边在该区间内
-					else if (i2 > end && i1 >= start && i1 <= end) {
-						delta.endDelta += i1 - end;
-					}
-					// 替换点包括整个区间
-					else if (i1 < start && i2 > end) {
-						delta.invaild = true;
-					}
-					// 替换点在该区间后不需要变动
-
-					break;
-				}
-			}
-		}
-	}
-
-	for (let i = 0; i < offsets.length; i++) {
-		const { start, end } = offsets[i];
-		const { startDelta, endDelta, invaild } = offsetsDelta[i];
-		replacement.push({
-			from: {
-				start: start,
-				end: end,
-			},
-			to:
-				invaild === true
-					? undefined
-					: {
-							start: start + startDelta,
-							end: end + endDelta,
-						},
-		});
-	}
-
-	await updateCommentOffsets(env, path, replacement);
+	await updateCommentOffsets(env, path, calcOffsetModification(offsets, diff));
 }

--- a/cloudflare-workers/src/administration.ts
+++ b/cloudflare-workers/src/administration.ts
@@ -1,4 +1,5 @@
-import { getMeta, setMeta } from './db';
+import { getComment, getMeta, getPaths, setMeta, setPath, updateCommentOffsets } from './db';
+import { ModifiedCommentBody } from './types';
 
 const encoder = new TextEncoder();
 
@@ -20,4 +21,249 @@ export async function setCommitHash(env: Env, hash: string) {
 export async function compareCommitHash(env: Env, hash: string): Promise<boolean> {
 	const storedHash = await getMeta(env, 'commit_hash');
 	return storedHash === hash;
+}
+
+export async function renameComments(env: Env, oldPath: string, newPath: string) {
+	if (oldPath == newPath) {
+		throw new Error('The path you want to rename from and to are the same');
+	}
+
+	const paths = await getPaths(env);
+	if (!paths.includes(oldPath)) {
+		throw new Error('The path you want to rename from does not exist');
+	}
+	if (paths.includes(newPath)) {
+		throw new Error('The path you want to rename to already exists');
+	}
+
+	await setPath(env, oldPath, newPath);
+}
+
+export async function modifyComments(env: Env, path: string, diff: ModifiedCommentBody['diff']) {
+	const paths = await getPaths(env);
+	if (!paths.includes(path)) {
+		throw new Error('The path you want to modify does not exist');
+	}
+
+	const replacement: {
+		from: {
+			start: number;
+			end: number;
+		};
+		to?: {
+			start: number;
+			end: number;
+		};
+	}[] = [];
+
+	// Sort diff by i1
+	diff = diff.sort((a, b) => a.i1 - b.i1);
+
+	function _calcDiff(
+		offsets: {
+			start: number;
+			end: number;
+		}[],
+		pseudoOffsetsDiffArr: {
+			beforeEverything: {
+				len: number;
+				diff: number;
+			};
+		},
+		offsetsDiffArr: {
+			len: number;
+			diff: number;
+		}[],
+	) {
+		for (const { tag, i1, i2, j1, j2 } of diff) {
+			// console.log('In diff:', tag, i1, i2, j1, j2);
+			switch (tag) {
+				case 'insert': {
+					const offsetIdx = offsets.findIndex((offset: { start: number; end: number }) => offset.start <= i1 && offset.end >= i1);
+					// 插入点在某个区间内
+					if (offsetIdx >= 0) {
+						// 更改区间长度
+						const diff = offsetsDiffArr[offsetIdx];
+						// console.log('  插入点在某个区间内：', diff.len, j2 - j1); // checked
+						diff.len += j2 - j1;
+					}
+					// 插入点在任意区间外
+					else {
+						// 更改距离插入位置最近的前一个区间的差分
+						const diff = offsets.findIndex((offset: { start: number }) => offset.start > i1) - 1;
+						// console.log('  插入点在任意区间外：', diff, j2 - j1); // checked
+						// 如果插入位置在所有 offset 区间前
+						if (diff == -1) {
+							pseudoOffsetsDiffArr.beforeEverything.diff += j2 - j1;
+						} else if (diff >= 0) {
+							offsetsDiffArr[diff].diff += j2 - j1;
+						}
+					}
+
+					break;
+				}
+
+				case 'replace':
+				case 'delete': {
+					// 如果该 diff 在所有 offset 区间前
+					if (i2 <= pseudoOffsetsDiffArr.beforeEverything.len + pseudoOffsetsDiffArr.beforeEverything.diff) {
+						// console.log('  该 diff 在所有 offset 区间前', i2 - i1 - (j2 - j1)); // checked
+						pseudoOffsetsDiffArr.beforeEverything.diff -= i2 - i1 - (j2 - j1);
+						break;
+					}
+
+					const offsetIdxs = offsets.map((_: any, idx: number) => idx);
+					offsetIdxs.unshift(-1);
+
+					for (const offsetIdx of offsetIdxs) {
+						const { start, end } = offsetIdx === -1 ? { start: 0, end: pseudoOffsetsDiffArr.beforeEverything.len } : offsets[offsetIdx];
+						const diff = offsetIdx === -1 ? pseudoOffsetsDiffArr.beforeEverything : offsetsDiffArr[offsetIdx];
+						// console.log('  offsetIdx:', offsetIdx, start, end, diff);
+
+						// 如果 diff 完全包含 offset
+						if (i1 <= start && i2 >= end) {
+							// console.log('  diff 完全包含 offset', diff); // checked
+							diff.len = 0;
+						}
+						// 如果 offset 完全包含 diff
+						else if (start <= i1 && end >= i2) {
+							// console.log('  offset 完全包含 diff', diff, diff.len - (i2 - i1 - (j2 - j1))); // checked
+							diff.len -= i2 - i1 - (j2 - j1);
+						}
+						// 如果 diff 左半边在 offset 内，右半边在 offset 外
+						else if (i1 >= start && i1 <= end) {
+							if (tag === 'delete') {
+								// console.log('  diff 左半边在 offset 内，右半边在 offset 外', diff, end - i1); // checked
+								diff.len -= end - i1;
+							}
+						}
+						// 如果 diff 右半边在 offset 内，左半边在 offset 外
+						else if (i2 >= start && i2 <= end) {
+							if (tag === 'delete') {
+								// console.log('  diff 右半边在 offset 内，左半边在 offset 外', diff, i2 - start); // checked
+								diff.len -= i2 - start;
+							}
+						}
+					}
+
+					// 如果有 diff 跨多段 offset，那么直接删除多段 offset 的 diff
+					if (tag === 'replace') {
+						const cross = offsetIdxs
+							.map((offsetIdx) => ({
+								offset: offsetIdx === -1 ? { start: 0, end: pseudoOffsetsDiffArr.beforeEverything.len } : offsets[offsetIdx],
+								diff: offsetIdx === -1 ? pseudoOffsetsDiffArr.beforeEverything : offsetsDiffArr[offsetIdx],
+							}))
+							.filter((d) => (i1 >= d.offset.start && i1 <= d.offset.end) || (i2 >= d.offset.start && i2 <= d.offset.end));
+						if (cross.length > 1) {
+							let len = cross.reduce((acc, d) => acc + d.diff.len, 0);
+							// 跨段 diff 转 len 补偿
+							len += cross.slice(-1).reduce((acc, d) => acc + d.diff.diff, 0);
+							for (const d of cross) {
+								// console.log('  跨段 replace', d, diff);
+								d.diff.len = 0;
+							}
+							cross[0].diff.diff += len - (i2 - i1 - (j2 - j1));
+						}
+					}
+
+					break;
+				}
+			}
+		}
+	}
+
+	// Distinct offsets
+	const offsets = [
+		...new Map((await getComment(env, { path })).map((comment) => comment.offset).map((offset) => [offset.start, offset.end])).entries(),
+	]
+		.map(([start, end]) => ({ start, end }))
+		.sort((a, b) => a.start - b.start);
+
+	if (offsets.length === 0) {
+		return;
+	}
+
+	const pseudoOffsetsDiffArr = {
+		beforeEverything: {
+			len: 0,
+			diff: offsets[0].start,
+		},
+	};
+
+	// offsets diff array
+	const offsetsDiffArr = offsets.map((offset, idx, that) => ({
+		len: offset.end - offset.start,
+		diff: idx === that.length - 1 ? 0 : that[idx + 1].start - offset.end,
+	}));
+
+	const diffPseudoOffsetsDiffArr = {
+		beforeEverything: {
+			len: pseudoOffsetsDiffArr.beforeEverything.diff,
+			diff: 0,
+		},
+	};
+
+	let lastDiffOffsetEnd = diffPseudoOffsetsDiffArr.beforeEverything.len;
+	const diffOffsets = offsetsDiffArr.map((diff) => {
+		const offset = {
+			start: lastDiffOffsetEnd + diff.len,
+			end: lastDiffOffsetEnd + diff.len + diff.diff,
+		};
+		lastDiffOffsetEnd = offset.end;
+		return offset;
+	});
+
+	const diffOffsetsDiffArr = diffOffsets.map((offset, idx, that) => ({
+		len: offset.end - offset.start,
+		diff: idx === that.length - 1 ? 0 : that[idx + 1].start - offset.end,
+	}));
+
+	// console.log('Initialalize:', offsets, pseudoOffsetsDiffArr, offsetsDiffArr);
+	// 计算 offset 更改
+	_calcDiff(offsets, pseudoOffsetsDiffArr, offsetsDiffArr);
+	// console.log('Finalalize:', offsets, pseudoOffsetsDiffArr, offsetsDiffArr);
+
+	// console.log('Diff Initialalize:', diffOffsets, diffPseudoOffsetsDiffArr, diffOffsetsDiffArr);
+	// 计算 diff.diff 更改
+	_calcDiff(diffOffsets, diffPseudoOffsetsDiffArr, diffOffsetsDiffArr);
+	// 应用 diff.diff 更改到 offset
+	for (const [idx, diff] of diffOffsetsDiffArr.entries()) {
+		offsetsDiffArr[idx].diff += diff.len - (diffOffsets[idx].end - diffOffsets[idx].start);
+	}
+	pseudoOffsetsDiffArr.beforeEverything.diff += diffPseudoOffsetsDiffArr.beforeEverything.len - offsets[0].start;
+	// console.log('Diff Finalalize:', diffOffsets, diffPseudoOffsetsDiffArr, diffOffsetsDiffArr);
+
+	let lastOffset = {
+		start: 0,
+		end: pseudoOffsetsDiffArr.beforeEverything.len,
+	};
+	let lastDiff = {
+		len: 0,
+		diff: pseudoOffsetsDiffArr.beforeEverything.diff,
+	};
+	// console.log('Check (pseudo):', lastOffset, lastDiff);
+	for (const [idx, diff] of offsetsDiffArr.entries()) {
+		const offset = offsets[idx];
+		// console.log('Check:', offset, diff);
+
+		const from = {
+			start: offset.start,
+			end: offset.end,
+		};
+		const to = {
+			start: lastOffset.end + lastDiff.diff,
+			end: lastOffset.end + lastDiff.diff + diff.len,
+		};
+
+		if (diff.len === 0) {
+			replacement.push({ from });
+		} else {
+			replacement.push({ from, to });
+		}
+
+		lastOffset = to;
+		lastDiff = diff;
+	}
+
+	await updateCommentOffsets(env, path, replacement);
 }

--- a/cloudflare-workers/src/db.ts
+++ b/cloudflare-workers/src/db.ts
@@ -110,16 +110,12 @@ export async function isPathExists(env: Env, ...path: string[]): Promise<boolean
 export async function getOffsets(env: Env, path: string): Promise<Offset[]> {
 	const db = env.DB;
 
-	const page = await db.prepare('SELECT * FROM pages WHERE path = ?').bind(path).first();
-
-	if (!page) {
-		return [];
-	}
-
-	return (await db.prepare('SELECT * FROM offsets WHERE page_id = ?').bind(page.id).all()).results.map((offset) => ({
-		start: offset.start as number,
-		end: offset.end as number,
-	}));
+	return (await db.prepare('SELECT * FROM offsets JOIN pages ON offsets.page_id = pages.id WHERE path = ?').bind(path).all()).results.map(
+		(offset) => ({
+			start: offset.start as number,
+			end: offset.end as number,
+		}),
+	);
 }
 
 export async function updateCommentOffsets(

--- a/cloudflare-workers/src/db.ts
+++ b/cloudflare-workers/src/db.ts
@@ -1,4 +1,4 @@
-import { GetComment, GetCommentRespBody, PostComment } from './types';
+import { GetComment, GetCommentRespBody, Offset, PostComment } from './types';
 
 export async function postComment(env: Env, req: PostComment) {
 	const db = env.DB;
@@ -105,6 +105,21 @@ export async function isPathExists(env: Env, ...path: string[]): Promise<boolean
 	}
 
 	return path.map((p) => res.results.some((r) => r.path === p));
+}
+
+export async function getOffsets(env: Env, path: string): Promise<Offset[]> {
+	const db = env.DB;
+
+	const page = await db.prepare('SELECT * FROM pages WHERE path = ?').bind(path).first();
+
+	if (!page) {
+		return [];
+	}
+
+	return (await db.prepare('SELECT * FROM offsets WHERE page_id = ?').bind(page.id).all()).results.map((offset) => ({
+		start: offset.start as number,
+		end: offset.end as number,
+	}));
 }
 
 export async function updateCommentOffsets(

--- a/cloudflare-workers/src/types.ts
+++ b/cloudflare-workers/src/types.ts
@@ -46,6 +46,18 @@ export type GetCommitHashRespBody = {
 	commit_hash: string | undefined;
 };
 
+export type ModifiedCommentBody = {
+	type: 'modified';
+	diff: { tag: 'replace' | 'delete' | 'insert'; i1: number; i2: number; j1: number; j2: number }[];
+};
+
+export type RenamedCommentBody = {
+	type: 'renamed';
+	to: string;
+};
+
+export type PatchCommentBody = ModifiedCommentBody | RenamedCommentBody;
+
 export type ResponseBody<T = {}> = {
 	status: 200;
 	data?: T;

--- a/cloudflare-workers/src/types.ts
+++ b/cloudflare-workers/src/types.ts
@@ -62,3 +62,8 @@ export type ResponseBody<T = {}> = {
 	status: 200;
 	data?: T;
 };
+
+export type Offset = {
+	start: number;
+	end: number;
+};

--- a/cloudflare-workers/src/types.ts
+++ b/cloudflare-workers/src/types.ts
@@ -48,6 +48,7 @@ export type GetCommitHashRespBody = {
 
 export type ModifiedCommentBody = {
 	type: 'modified';
+	// @see: https://docs.python.org/3/library/difflib.html#difflib.SequenceMatcher.get_opcodes
 	diff: { tag: 'replace' | 'delete' | 'insert'; i1: number; i2: number; j1: number; j2: number }[];
 };
 

--- a/cloudflare-workers/src/types.ts
+++ b/cloudflare-workers/src/types.ts
@@ -67,3 +67,14 @@ export type Offset = {
 	start: number;
 	end: number;
 };
+
+export type Replacement = {
+	from: {
+		start: number;
+		end: number;
+	};
+	to?: {
+		start: number;
+		end: number;
+	};
+};

--- a/cloudflare-workers/src/utils.ts
+++ b/cloudflare-workers/src/utils.ts
@@ -9,6 +9,7 @@ type OffsetDelta = {
 export function calcOffsetModification(offsets: Offset[], diff: ModifiedCommentBody['diff']): Replacement[] {
 	const offsetsDelta: OffsetDelta[] = Array.from({ length: offsets.length }, () => ({ startDelta: 0, endDelta: 0 }));
 
+	// i1, i2, j1, j2, start, end 均为左闭右开
 	for (const { tag, i1, i2, j1, j2 } of diff) {
 		for (let i = 0; i < offsets.length; i++) {
 			const { start, end } = offsets[i];
@@ -33,7 +34,7 @@ export function calcOffsetModification(offsets: Offset[], diff: ModifiedCommentB
 				case 'delete':
 				case 'replace': {
 					// 替换点在该区间前
-					if (i2 < start) {
+					if (i2 <= start) {
 						const deltaLength = j2 - j1 - (i2 - i1);
 						delta.startDelta += deltaLength;
 						delta.endDelta += deltaLength;
@@ -44,17 +45,17 @@ export function calcOffsetModification(offsets: Offset[], diff: ModifiedCommentB
 						delta.endDelta += deltaLength;
 					}
 					// 替换点右半边在该区间内，左半边在该区间外
-					else if (i1 < start && i2 >= start && i2 <= end) {
+					else if (i1 < start && i2 > start && i2 <= end) {
 						const deltaLength = i1 - start; // 获取替换部分
 						delta.startDelta += deltaLength;
 						delta.endDelta += deltaLength - (i2 - start);
 					}
 					// 替换点右半边在该区间外，左半边在该区间内
-					else if (i2 > end && i1 >= start && i1 < end) {
+					else if (i2 >= end && i1 >= start && i1 < end) {
 						delta.endDelta += i1 - end;
 					}
 					// 替换点包括整个区间
-					else if (i1 < start && i2 > end) {
+					else if (i1 < start && i2 >= end) {
 						delta.invalid = true;
 					}
 					// 替换点在该区间后不需要变动

--- a/cloudflare-workers/src/utils.ts
+++ b/cloudflare-workers/src/utils.ts
@@ -22,7 +22,7 @@ export function calcOffsetModification(offsets: Offset[], diff: ModifiedCommentB
 						delta.endDelta += insertedLength;
 					}
 					// 插入点在该区间内
-					else if (start <= i1 && i1 <= end) {
+					else if (start <= i1 && i1 < end) {
 						delta.endDelta += insertedLength;
 					}
 					// 插入点在该区间外不需要变动
@@ -50,7 +50,7 @@ export function calcOffsetModification(offsets: Offset[], diff: ModifiedCommentB
 						delta.endDelta += deltaLength - (i2 - start);
 					}
 					// 替换点右半边在该区间外，左半边在该区间内
-					else if (i2 > end && i1 >= start && i1 <= end) {
+					else if (i2 > end && i1 >= start && i1 < end) {
 						delta.endDelta += i1 - end;
 					}
 					// 替换点包括整个区间

--- a/cloudflare-workers/src/utils.ts
+++ b/cloudflare-workers/src/utils.ts
@@ -1,0 +1,89 @@
+import { ModifiedCommentBody, Offset, Replacement } from './types';
+
+type OffsetDelta = {
+	startDelta: number;
+	endDelta: number;
+	invaild?: boolean;
+};
+
+export function calcOffsetModification(offsets: Offset[], diff: ModifiedCommentBody['diff']): Replacement[] {
+	const offsetsDelta: OffsetDelta[] = Array.from({ length: offsets.length }, () => ({ startDelta: 0, endDelta: 0 }));
+
+	for (const { tag, i1, i2, j1, j2 } of diff) {
+		for (let i = 0; i < offsets.length; i++) {
+			const { start, end } = offsets[i];
+			const delta = offsetsDelta[i];
+			switch (tag) {
+				case 'insert': {
+					const insertedLength = j2 - j1;
+					// 插入点在该区间前
+					if (i1 < start) {
+						delta.startDelta += insertedLength;
+						delta.endDelta += insertedLength;
+					}
+					// 插入点在该区间内
+					else if (start <= i1 && i1 <= end) {
+						delta.endDelta += insertedLength;
+					}
+					// 插入点在该区间外不需要变动
+
+					break;
+				}
+
+				case 'delete':
+				case 'replace': {
+					// 替换点在该区间前
+					if (i2 < start) {
+						const deltaLength = j2 - j1 - (i2 - i1);
+						delta.startDelta += deltaLength;
+						delta.endDelta += deltaLength;
+					}
+					// 替换点在该区间内
+					else if (i1 >= start && i2 <= end) {
+						const deltaLength = j2 - j1 - (i2 - i1);
+						delta.endDelta += deltaLength;
+					}
+					// 替换点右半边在该区间内，左半边在该区间外
+					else if (i1 < start && i2 >= start && i2 <= end) {
+						const deltaLength = i1 - start; // 获取替换部分
+						delta.startDelta += deltaLength;
+						delta.endDelta += deltaLength - (i2 - start);
+					}
+					// 替换点右半边在该区间外，左半边在该区间内
+					else if (i2 > end && i1 >= start && i1 <= end) {
+						delta.endDelta += i1 - end;
+					}
+					// 替换点包括整个区间
+					else if (i1 < start && i2 > end) {
+						delta.invaild = true;
+					}
+					// 替换点在该区间后不需要变动
+
+					break;
+				}
+			}
+		}
+	}
+
+	const replacement: Replacement[] = [];
+
+	for (let i = 0; i < offsets.length; i++) {
+		const { start, end } = offsets[i];
+		const { startDelta, endDelta, invaild } = offsetsDelta[i];
+		replacement.push({
+			from: {
+				start: start,
+				end: end,
+			},
+			to:
+				invaild === true
+					? undefined
+					: {
+							start: start + startDelta,
+							end: end + endDelta,
+						},
+		});
+	}
+
+	return replacement;
+}

--- a/cloudflare-workers/src/utils.ts
+++ b/cloudflare-workers/src/utils.ts
@@ -3,7 +3,7 @@ import { ModifiedCommentBody, Offset, Replacement } from './types';
 type OffsetDelta = {
 	startDelta: number;
 	endDelta: number;
-	invaild?: boolean;
+	invalid?: boolean;
 };
 
 export function calcOffsetModification(offsets: Offset[], diff: ModifiedCommentBody['diff']): Replacement[] {
@@ -55,7 +55,7 @@ export function calcOffsetModification(offsets: Offset[], diff: ModifiedCommentB
 					}
 					// 替换点包括整个区间
 					else if (i1 < start && i2 > end) {
-						delta.invaild = true;
+						delta.invalid = true;
 					}
 					// 替换点在该区间后不需要变动
 
@@ -69,7 +69,7 @@ export function calcOffsetModification(offsets: Offset[], diff: ModifiedCommentB
 
 	for (let i = 0; i < offsets.length; i++) {
 		const { start, end } = offsets[i];
-		const { startDelta, endDelta, invaild } = offsetsDelta[i];
+		const { startDelta, endDelta, invalid: invaild } = offsetsDelta[i];
 		replacement.push({
 			from: {
 				start: start,

--- a/cloudflare-workers/test/index.spec.ts
+++ b/cloudflare-workers/test/index.spec.ts
@@ -1,12 +1,120 @@
 // test/index.spec.ts
-import { env, createExecutionContext, waitOnExecutionContext, SELF } from 'cloudflare:test';
 import { describe, it, expect } from 'vitest';
 import { calcOffsetModification } from '../src/utils';
 import { ModifiedCommentBody, Offset } from '../src/types';
 
 describe('Commit offset patch', () => {
+	it('Insert inner unit test', () => {
+		const offsets: Offset[] = [
+			{ start: 0, end: 10 },
+			{ start: 20, end: 30 },
+		];
+
+		const diff: ModifiedCommentBody['diff'] = [{ tag: 'insert', i1: 5, i2: 5, j1: 5, j2: 10 }];
+
+		const res = calcOffsetModification(offsets, diff);
+
+		expect(res).toEqual([
+			{ from: { start: 0, end: 10 }, to: { start: 0, end: 15 } },
+			{ from: { start: 20, end: 30 }, to: { start: 25, end: 35 } },
+		]);
+	});
+
+	it('Insert before unit test', () => {
+		const offsets: Offset[] = [
+			{ start: 0, end: 10 },
+			{ start: 20, end: 30 },
+		];
+
+		const diff: ModifiedCommentBody['diff'] = [{ tag: 'insert', i1: 15, i2: 15, j1: 15, j2: 20 }];
+
+		const res = calcOffsetModification(offsets, diff);
+
+		expect(res).toEqual([
+			{ from: { start: 0, end: 10 }, to: { start: 0, end: 10 } },
+			{ from: { start: 20, end: 30 }, to: { start: 25, end: 35 } },
+		]);
+	});
+
+	it('Delete before unit test', () => {
+		const offsets: Offset[] = [
+			{ start: 0, end: 10 },
+			{ start: 20, end: 30 },
+		];
+
+		const diff: ModifiedCommentBody['diff'] = [{ tag: 'delete', i1: 15, i2: 20, j1: 15, j2: 15 }];
+
+		const res = calcOffsetModification(offsets, diff);
+
+		expect(res).toEqual([
+			{ from: { start: 0, end: 10 }, to: { start: 0, end: 10 } },
+			{ from: { start: 20, end: 30 }, to: { start: 15, end: 25 } },
+		]);
+	});
+
+	it('Replace inner unit test', () => {
+		const offsets: Offset[] = [
+			{ start: 0, end: 10 },
+			{ start: 20, end: 30 },
+		];
+
+		const diff: ModifiedCommentBody['diff'] = [{ tag: 'replace', i1: 5, i2: 8, j1: 5, j2: 10 }];
+
+		const res = calcOffsetModification(offsets, diff);
+
+		expect(res).toEqual([
+			{ from: { start: 0, end: 10 }, to: { start: 0, end: 12 } },
+			{ from: { start: 20, end: 30 }, to: { start: 22, end: 32 } },
+		]);
+	});
+
+	it('Replace right unit test', () => {
+		const offsets: Offset[] = [
+			{ start: 0, end: 10 },
+			{ start: 20, end: 30 },
+		];
+
+		const diff: ModifiedCommentBody['diff'] = [{ tag: 'replace', i1: 5, i2: 15, j1: 5, j2: 10 }];
+
+		const res = calcOffsetModification(offsets, diff);
+
+		expect(res).toEqual([
+			{ from: { start: 0, end: 10 }, to: { start: 0, end: 5 } },
+			{ from: { start: 20, end: 30 }, to: { start: 15, end: 25 } },
+		]);
+	});
+
+	it('Replace left unit test', () => {
+		const offsets: Offset[] = [
+			{ start: 0, end: 10 },
+			{ start: 20, end: 30 },
+		];
+
+		const diff: ModifiedCommentBody['diff'] = [{ tag: 'replace', i1: 15, i2: 25, j1: 15, j2: 20 }];
+
+		const res = calcOffsetModification(offsets, diff);
+
+		expect(res).toEqual([
+			{ from: { start: 0, end: 10 }, to: { start: 0, end: 10 } },
+			{ from: { start: 20, end: 30 }, to: { start: 15, end: 20 } },
+		]);
+	});
+
+	it('Replace union unit test', () => {
+		const offsets: Offset[] = [
+			{ start: 0, end: 10 },
+			{ start: 20, end: 30 },
+		];
+
+		const diff: ModifiedCommentBody['diff'] = [{ tag: 'replace', i1: 5, i2: 35, j1: 5, j2: 10 }];
+
+		const res = calcOffsetModification(offsets, diff);
+
+		expect(res).toEqual([{ from: { start: 0, end: 10 }, to: { start: 0, end: 5 } }, { from: { start: 20, end: 30 } }]);
+	});
+
 	// https://github.com/OI-wiki/OI-wiki/blob/master/docs/index.md
-	it('OI-Wiki index unit test', async () => {
+	it('OI-Wiki index unit test', () => {
 		const offsets: Offset[] = [
 			{ start: 372, end: 439 },
 			{ start: 441, end: 586 },

--- a/cloudflare-workers/test/index.spec.ts
+++ b/cloudflare-workers/test/index.spec.ts
@@ -1,25 +1,35 @@
 // test/index.spec.ts
 import { env, createExecutionContext, waitOnExecutionContext, SELF } from 'cloudflare:test';
 import { describe, it, expect } from 'vitest';
-import worker from '../src/index';
+import { calcOffsetModification } from '../src/utils';
+import { ModifiedCommentBody, Offset } from '../src/types';
 
-// For now, you'll need to do something like this to get a correctly-typed
-// `Request` to pass to `worker.fetch()`.
-const IncomingRequest = Request<unknown, IncomingRequestCfProperties>;
+describe('Commit offset patch', () => {
+	// https://github.com/OI-wiki/OI-wiki/blob/master/docs/index.md
+	it('OI-Wiki index unit test', async () => {
+		const offsets: Offset[] = [
+			{ start: 372, end: 439 },
+			{ start: 441, end: 586 },
+			{ start: 588, end: 744 },
+			{ start: 746, end: 810 },
+		];
+		const diff: ModifiedCommentBody['diff'] = [
+			{ tag: 'delete', i1: 20, i2: 298, j1: 20, j2: 20 },
+			{ tag: 'replace', i1: 420, i2: 423, j1: 142, j2: 145 },
+			{ tag: 'insert', i1: 538, i2: 538, j1: 260, j2: 265 },
+			{ tag: 'insert', i1: 586, i2: 586, j1: 313, j2: 321 },
+			{ tag: 'delete', i1: 696, i2: 712, j1: 431, j2: 431 },
+			{ tag: 'replace', i1: 752, i2: 755, j1: 471, j2: 473 },
+			{ tag: 'replace', i1: 770, i2: 773, j1: 488, j2: 490 },
+		];
 
-describe('Hello World worker', () => {
-	it('responds with Hello World! (unit style)', async () => {
-		const request = new IncomingRequest('http://example.com');
-		// Create an empty context to pass to `worker.fetch()`.
-		const ctx = createExecutionContext();
-		const response = await worker.fetch(request, env, ctx);
-		// Wait for all `Promise`s passed to `ctx.waitUntil()` to settle before running test assertions
-		await waitOnExecutionContext(ctx);
-		expect(await response.text()).toMatchInlineSnapshot(`"Hello World!"`);
-	});
+		const res = calcOffsetModification(offsets, diff);
 
-	it('responds with Hello World! (integration style)', async () => {
-		const response = await SELF.fetch('https://example.com');
-		expect(await response.text()).toMatchInlineSnapshot(`"Hello World!"`);
+		expect(res).toEqual([
+			{ from: { start: 372, end: 439 }, to: { start: 94, end: 161 } },
+			{ from: { start: 441, end: 586 }, to: { start: 163, end: 313 } },
+			{ from: { start: 588, end: 744 }, to: { start: 323, end: 463 } },
+			{ from: { start: 746, end: 810 }, to: { start: 465, end: 527 } },
+		]);
 	});
 });

--- a/cloudflare-workers/yarn.lock
+++ b/cloudflare-workers/yarn.lock
@@ -2,6 +2,14 @@
 # yarn lockfile v1
 
 
+"@ampproject/remapping@^2.3.0":
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/@ampproject/remapping/-/remapping-2.3.0.tgz#ed441b6fa600072520ce18b43d2c8cc8caecc7f4"
+  integrity sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==
+  dependencies:
+    "@jridgewell/gen-mapping" "^0.3.5"
+    "@jridgewell/trace-mapping" "^0.3.24"
+
 "@cloudflare/kv-asset-handler@0.3.4":
   version "0.3.4"
   resolved "https://registry.yarnpkg.com/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.3.4.tgz#5cc152847c8ae4d280ec5d7f4f6ba8c976b585c3"
@@ -28,50 +36,55 @@
   resolved "https://registry.yarnpkg.com/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20240701.0.tgz#064d8ded54443ac8d4181bdb2d93113f7fb63c81"
   integrity sha512-XAZa4ZP+qyTn6JQQACCPH09hGZXP2lTnWKkmg5mPwT8EyRzCKLkczAf98vPP5bq7JZD/zORdFWRY0dOTap8zTQ==
 
-"@cloudflare/workerd-darwin-64@1.20240718.0":
-  version "1.20240718.0"
-  resolved "https://registry.yarnpkg.com/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20240718.0.tgz#46f438fb86ccd4772c29db52fe1d076bc9e6ffb4"
-  integrity sha512-BsPZcSCgoGnufog2GIgdPuiKicYTNyO/Dp++HbpLRH+yQdX3x4aWx83M+a0suTl1xv76dO4g9aw7SIB6OSgIyQ==
+"@cloudflare/workerd-darwin-64@1.20240806.0":
+  version "1.20240806.0"
+  resolved "https://registry.yarnpkg.com/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20240806.0.tgz#9e7f8b6bd10d06d1fae6198aea467b1f3df809ce"
+  integrity sha512-FqcVBBCO//I39K5F+HqE/v+UkqY1UrRnS653Jv+XsNNH9TpX5fTs7VCKG4kDSnmxlAaKttyIN5sMEt7lpuNExQ==
 
 "@cloudflare/workerd-darwin-arm64@1.20240701.0":
   version "1.20240701.0"
   resolved "https://registry.yarnpkg.com/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20240701.0.tgz#042e49592bf9ef9e74d7f85c885cc3bda356c96c"
   integrity sha512-w80ZVAgfH4UwTz7fXZtk7KmS2FzlXniuQm4ku4+cIgRTilBAuKqjpOjwUCbx5g13Gqcm9NuiHce+IDGtobRTIQ==
 
-"@cloudflare/workerd-darwin-arm64@1.20240718.0":
-  version "1.20240718.0"
-  resolved "https://registry.yarnpkg.com/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20240718.0.tgz#70e1dca5de4869ef3a9b9e296e934848bca6c74f"
-  integrity sha512-nlr4gaOO5gcJerILJQph3+2rnas/nx/lYsuaot1ntHu4LAPBoQo1q/Pucj2cSIav4UiMzTbDmoDwPlls4Kteog==
+"@cloudflare/workerd-darwin-arm64@1.20240806.0":
+  version "1.20240806.0"
+  resolved "https://registry.yarnpkg.com/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20240806.0.tgz#304906b959db2095139df6349fff4fe4b0cc99d1"
+  integrity sha512-8c3KvmzYp/wg+82KHSOzDetJK+pThH4MTrU1OsjmsR2cUfedm5dk5Lah9/0Ld68+6A0umFACi4W2xJHs/RoBpA==
 
 "@cloudflare/workerd-linux-64@1.20240701.0":
   version "1.20240701.0"
   resolved "https://registry.yarnpkg.com/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20240701.0.tgz#5ff73dcd0b0615877baa0ae4fa057ea244e326f3"
   integrity sha512-UWLr/Anxwwe/25nGv451MNd2jhREmPt/ws17DJJqTLAx6JxwGWA15MeitAIzl0dbxRFAJa+0+R8ag2WR3F/D6g==
 
-"@cloudflare/workerd-linux-64@1.20240718.0":
-  version "1.20240718.0"
-  resolved "https://registry.yarnpkg.com/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20240718.0.tgz#802c04a1a5729f3881c675be3d158ee06c6b1a36"
-  integrity sha512-LJ/k3y47pBcjax0ee4K+6ZRrSsqWlfU4lbU8Dn6u5tSC9yzwI4YFNXDrKWInB0vd7RT3w4Yqq1S6ZEbfRrqVUg==
+"@cloudflare/workerd-linux-64@1.20240806.0":
+  version "1.20240806.0"
+  resolved "https://registry.yarnpkg.com/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20240806.0.tgz#0ac0771a8aed2e702626d1a4a4672e86041de60a"
+  integrity sha512-/149Bpxw4e2p5QqnBc06g0mx+4sZYh9j0doilnt0wk/uqYkLp0DdXGMQVRB74sBLg2UD3wW8amn1w3KyFhK2tQ==
 
 "@cloudflare/workerd-linux-arm64@1.20240701.0":
   version "1.20240701.0"
   resolved "https://registry.yarnpkg.com/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20240701.0.tgz#b0e5e5bf00fb41ac94f93f7dea7ffd306f468685"
   integrity sha512-3kCnF9kYgov1ggpuWbgpXt4stPOIYtVmPCa7MO2xhhA0TWP6JDUHRUOsnmIgKrvDjXuXqlK16cdg3v+EWsaPJg==
 
-"@cloudflare/workerd-linux-arm64@1.20240718.0":
-  version "1.20240718.0"
-  resolved "https://registry.yarnpkg.com/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20240718.0.tgz#cebff9115d48f8d0c2649fdf86ef46b726d1841f"
-  integrity sha512-zBEZvy88EcAMGRGfuVtS00Yl7lJdUM9sH7i651OoL+q0Plv9kphlCC0REQPwzxrEYT1qibSYtWcD9IxQGgx2/g==
+"@cloudflare/workerd-linux-arm64@1.20240806.0":
+  version "1.20240806.0"
+  resolved "https://registry.yarnpkg.com/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20240806.0.tgz#9787fe9c274db54ca5b0e4c4133eb49e55f75e48"
+  integrity sha512-lacDWY3S1rKL/xT6iMtTQJEKmTTKrBavPczInEuBFXElmrS6IwVjZwv8hhVm32piyNt/AuFu9BYoJALi9D85/g==
 
 "@cloudflare/workerd-windows-64@1.20240701.0":
   version "1.20240701.0"
   resolved "https://registry.yarnpkg.com/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20240701.0.tgz#710583329e7fef26092fdccf021e669434cc6acb"
   integrity sha512-6IPGITRAeS67j3BH1rN4iwYWDt47SqJG7KlZJ5bB4UaNAia4mvMBSy/p2p4vA89bbXoDRjMtEvRu7Robu6O7hQ==
 
-"@cloudflare/workerd-windows-64@1.20240718.0":
-  version "1.20240718.0"
-  resolved "https://registry.yarnpkg.com/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20240718.0.tgz#940893e62df7f5a8ec895572b834c95c1e256fbd"
-  integrity sha512-YpCRvvT47XanFum7C3SedOZKK6BfVhqmwdAAVAQFyc4gsCdegZo0JkUkdloC/jwuWlbCACOG2HTADHOqyeolzQ==
+"@cloudflare/workerd-windows-64@1.20240806.0":
+  version "1.20240806.0"
+  resolved "https://registry.yarnpkg.com/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20240806.0.tgz#0bd854f3b1bde3748ae4054b1c54662a7ee2bde0"
+  integrity sha512-hC6JEfTSQK6//Lg+D54TLVn1ceTPY+fv4MXqDZIYlPP53iN+dL8Xd0utn2SG57UYdlL5FRAhm/EWHcATZg1RgA==
+
+"@cloudflare/workers-shared@0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@cloudflare/workers-shared/-/workers-shared-0.2.0.tgz#0888a464b9e5b6b5a12bfeb0c1110d9fe04ce3c4"
+  integrity sha512-tIWLooWkBMuoKRk72lr6YrEtVlVdUTtAGVmPOnUroMrnri/9YLx+mVawL0/egDgSGmPbmvkdBFsUGRuI+aZmxg==
 
 "@cloudflare/workers-types@^4.20240712.0":
   version "4.20240712.0"
@@ -328,19 +341,26 @@
   resolved "https://registry.yarnpkg.com/@fastify/busboy/-/busboy-2.1.1.tgz#b9da6a878a371829a0502c9b6c1c143ef6663f4d"
   integrity sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==
 
-"@jest/schemas@^29.6.3":
-  version "29.6.3"
-  resolved "https://registry.yarnpkg.com/@jest/schemas/-/schemas-29.6.3.tgz#430b5ce8a4e0044a7e3819663305a7b3091c8e03"
-  integrity sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==
+"@jridgewell/gen-mapping@^0.3.5":
+  version "0.3.5"
+  resolved "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz#dcce6aff74bdf6dad1a95802b69b04a2fcb1fb36"
+  integrity sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==
   dependencies:
-    "@sinclair/typebox" "^0.27.8"
+    "@jridgewell/set-array" "^1.2.1"
+    "@jridgewell/sourcemap-codec" "^1.4.10"
+    "@jridgewell/trace-mapping" "^0.3.24"
 
-"@jridgewell/resolve-uri@^3.0.3":
+"@jridgewell/resolve-uri@^3.0.3", "@jridgewell/resolve-uri@^3.1.0":
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz#7a0ee601f60f99a20c7c7c5ff0c80388c1189bd6"
   integrity sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==
 
-"@jridgewell/sourcemap-codec@^1.4.10", "@jridgewell/sourcemap-codec@^1.4.15":
+"@jridgewell/set-array@^1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@jridgewell/set-array/-/set-array-1.2.1.tgz#558fb6472ed16a4c850b889530e6b36438c49280"
+  integrity sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==
+
+"@jridgewell/sourcemap-codec@^1.4.10", "@jridgewell/sourcemap-codec@^1.4.14", "@jridgewell/sourcemap-codec@^1.5.0":
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz#3188bcb273a414b0d215fd22a58540b989b9409a"
   integrity sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==
@@ -352,6 +372,14 @@
   dependencies:
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
+
+"@jridgewell/trace-mapping@^0.3.24":
+  version "0.3.25"
+  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz#15f190e98895f3fc23276ee14bc76b675c2e50f0"
+  integrity sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==
+  dependencies:
+    "@jridgewell/resolve-uri" "^3.1.0"
+    "@jridgewell/sourcemap-codec" "^1.4.14"
 
 "@rollup/rollup-android-arm-eabi@4.18.1":
   version "4.18.1"
@@ -433,11 +461,6 @@
   resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.18.1.tgz#0cb240c147c0dfd0e3eaff4cc060a772d39e155c"
   integrity sha512-yjk2MAkQmoaPYCSu35RLJ62+dz358nE83VfTePJRp8CG7aMg25mEJYpXFiD+NcevhX8LxD5OP5tktPXnXN7GDw==
 
-"@sinclair/typebox@^0.27.8":
-  version "0.27.8"
-  resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.27.8.tgz#6667fac16c436b5434a387a34dedb013198f6e6e"
-  integrity sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==
-
 "@types/estree@1.0.5", "@types/estree@^1.0.0":
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.5.tgz#a6ce3e556e00fd9895dd872dd172ad0d4bd687f4"
@@ -457,66 +480,68 @@
   dependencies:
     undici-types "~5.26.4"
 
-"@vitest/expect@1.5.0":
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/@vitest/expect/-/expect-1.5.0.tgz#961190510a2723bd4abf5540bcec0a4dfd59ef14"
-  integrity sha512-0pzuCI6KYi2SIC3LQezmxujU9RK/vwC1U9R0rLuGlNGcOuDWxqWKu6nUdFsX9tH1WU0SXtAxToOsEjeUn1s3hA==
+"@vitest/expect@2.0.5":
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/@vitest/expect/-/expect-2.0.5.tgz#f3745a6a2c18acbea4d39f5935e913f40d26fa86"
+  integrity sha512-yHZtwuP7JZivj65Gxoi8upUN2OzHTi3zVfjwdpu2WrvCZPLwsJ2Ey5ILIPccoW23dd/zQBlJ4/dhi7DWNyXCpA==
   dependencies:
-    "@vitest/spy" "1.5.0"
-    "@vitest/utils" "1.5.0"
-    chai "^4.3.10"
+    "@vitest/spy" "2.0.5"
+    "@vitest/utils" "2.0.5"
+    chai "^5.1.1"
+    tinyrainbow "^1.2.0"
 
-"@vitest/runner@1.5.0":
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/@vitest/runner/-/runner-1.5.0.tgz#1f7cb78ee4064e73e53d503a19c1b211c03dfe0c"
-  integrity sha512-7HWwdxXP5yDoe7DTpbif9l6ZmDwCzcSIK38kTSIt6CFEpMjX4EpCgT6wUmS0xTXqMI6E/ONmfgRKmaujpabjZQ==
+"@vitest/pretty-format@2.0.5", "@vitest/pretty-format@^2.0.5":
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/@vitest/pretty-format/-/pretty-format-2.0.5.tgz#91d2e6d3a7235c742e1a6cc50e7786e2f2979b1e"
+  integrity sha512-h8k+1oWHfwTkyTkb9egzwNMfJAEx4veaPSnMeKbVSjp4euqGSbQlm5+6VHwTr7u4FJslVVsUG5nopCaAYdOmSQ==
   dependencies:
-    "@vitest/utils" "1.5.0"
-    p-limit "^5.0.0"
-    pathe "^1.1.1"
+    tinyrainbow "^1.2.0"
 
-"@vitest/snapshot@1.5.0":
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/@vitest/snapshot/-/snapshot-1.5.0.tgz#cd2d611fd556968ce8fb6b356a09b4593c525947"
-  integrity sha512-qpv3fSEuNrhAO3FpH6YYRdaECnnRjg9VxbhdtPwPRnzSfHVXnNzzrpX4cJxqiwgRMo7uRMWDFBlsBq4Cr+rO3A==
+"@vitest/runner@2.0.5":
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/@vitest/runner/-/runner-2.0.5.tgz#89197e712bb93513537d6876995a4843392b2a84"
+  integrity sha512-TfRfZa6Bkk9ky4tW0z20WKXFEwwvWhRY+84CnSEtq4+3ZvDlJyY32oNTJtM7AW9ihW90tX/1Q78cb6FjoAs+ig==
   dependencies:
-    magic-string "^0.30.5"
-    pathe "^1.1.1"
-    pretty-format "^29.7.0"
+    "@vitest/utils" "2.0.5"
+    pathe "^1.1.2"
 
-"@vitest/spy@1.5.0":
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/@vitest/spy/-/spy-1.5.0.tgz#1369a1bec47f46f18eccfa45f1e8fbb9b5e15e77"
-  integrity sha512-vu6vi6ew5N5MMHJjD5PoakMRKYdmIrNJmyfkhRpQt5d9Ewhw9nZ5Aqynbi3N61bvk9UvZ5UysMT6ayIrZ8GA9w==
+"@vitest/snapshot@2.0.5":
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/@vitest/snapshot/-/snapshot-2.0.5.tgz#a2346bc5013b73c44670c277c430e0334690a162"
+  integrity sha512-SgCPUeDFLaM0mIUHfaArq8fD2WbaXG/zVXjRupthYfYGzc8ztbFbu6dUNOblBG7XLMR1kEhS/DNnfCZ2IhdDew==
   dependencies:
-    tinyspy "^2.2.0"
+    "@vitest/pretty-format" "2.0.5"
+    magic-string "^0.30.10"
+    pathe "^1.1.2"
 
-"@vitest/utils@1.5.0":
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/@vitest/utils/-/utils-1.5.0.tgz#90c9951f4516f6d595da24876b58e615f6c99863"
-  integrity sha512-BDU0GNL8MWkRkSRdNFvCUCAVOeHaUlVJ9Tx0TYBZyXaaOTmGtUFObzchCivIBrIwKzvZA7A9sCejVhXM2aY98A==
+"@vitest/spy@2.0.5":
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/@vitest/spy/-/spy-2.0.5.tgz#590fc07df84a78b8e9dd976ec2090920084a2b9f"
+  integrity sha512-c/jdthAhvJdpfVuaexSrnawxZz6pywlTPe84LUB2m/4t3rl2fTo9NFGBG4oWgaD+FTgDDV8hJ/nibT7IfH3JfA==
   dependencies:
-    diff-sequences "^29.6.3"
+    tinyspy "^3.0.0"
+
+"@vitest/utils@2.0.5":
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/@vitest/utils/-/utils-2.0.5.tgz#6f8307a4b6bc6ceb9270007f73c67c915944e926"
+  integrity sha512-d8HKbqIcya+GR67mkZbrzhS5kKhtp8dQLcmRZLGTscGVg7yImT82cIrhtn2L8+VujWcy6KZweApgNmPsTAO/UQ==
+  dependencies:
+    "@vitest/pretty-format" "2.0.5"
     estree-walker "^3.0.3"
-    loupe "^2.3.7"
-    pretty-format "^29.7.0"
+    loupe "^3.1.1"
+    tinyrainbow "^1.2.0"
 
-acorn-walk@^8.2.0, acorn-walk@^8.3.2:
+acorn-walk@^8.2.0:
   version "8.3.3"
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.3.3.tgz#9caeac29eefaa0c41e3d4c65137de4d6f34df43e"
   integrity sha512-MxXdReSRhGO7VlFe1bRG/oI7/mdLV9B9JJT0N8vZOhF7gFRR5l3M8W9G8JxmKV+JC5mGqJ0QvqfSOLsCPa4nUw==
   dependencies:
     acorn "^8.11.0"
 
-acorn@^8.11.0, acorn@^8.11.3, acorn@^8.8.0:
+acorn@^8.11.0, acorn@^8.8.0:
   version "8.12.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.12.1.tgz#71616bdccbe25e27a54439e0046e89ca76df2248"
   integrity sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==
-
-ansi-styles@^5.0.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-5.2.0.tgz#07449690ad45777d1924ac2abb2fc8895dba836b"
-  integrity sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==
 
 anymatch@~3.1.2:
   version "3.1.3"
@@ -533,10 +558,10 @@ as-table@^1.0.36:
   dependencies:
     printable-characters "^1.0.42"
 
-assertion-error@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-1.1.0.tgz#e60b6b0e8f301bd97e5375215bda406c85118c0b"
-  integrity sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==
+assertion-error@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-2.0.1.tgz#f641a196b335690b1070bf00b6e7593fec190bf7"
+  integrity sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==
 
 binary-extensions@^2.0.0:
   version "2.3.0"
@@ -573,25 +598,21 @@ capnp-ts@^0.7.0:
     debug "^4.3.1"
     tslib "^2.2.0"
 
-chai@^4.3.10:
-  version "4.4.1"
-  resolved "https://registry.yarnpkg.com/chai/-/chai-4.4.1.tgz#3603fa6eba35425b0f2ac91a009fe924106e50d1"
-  integrity sha512-13sOfMv2+DWduEU+/xbun3LScLoqN17nBeTLUsmDfKdoiC1fr0n9PU4guu4AhRcOVFk/sW8LyZWHuhWtQZiF+g==
+chai@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/chai/-/chai-5.1.1.tgz#f035d9792a22b481ead1c65908d14bb62ec1c82c"
+  integrity sha512-pT1ZgP8rPNqUgieVaEY+ryQr6Q4HXNg8Ei9UnLUrjN4IA7dvQC5JB+/kxVcPNDHyBcc/26CXPkbNzq3qwrOEKA==
   dependencies:
-    assertion-error "^1.1.0"
-    check-error "^1.0.3"
-    deep-eql "^4.1.3"
-    get-func-name "^2.0.2"
-    loupe "^2.3.6"
-    pathval "^1.1.1"
-    type-detect "^4.0.8"
+    assertion-error "^2.0.1"
+    check-error "^2.1.1"
+    deep-eql "^5.0.1"
+    loupe "^3.1.0"
+    pathval "^2.0.0"
 
-check-error@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/check-error/-/check-error-1.0.3.tgz#a6502e4312a7ee969f646e83bb3ddd56281bd694"
-  integrity sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==
-  dependencies:
-    get-func-name "^2.0.2"
+check-error@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/check-error/-/check-error-2.1.1.tgz#87eb876ae71ee388fa0471fe423f494be1d96ccc"
+  integrity sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==
 
 chokidar@^3.5.3:
   version "3.6.0"
@@ -612,11 +633,6 @@ cjs-module-lexer@^1.2.3:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/cjs-module-lexer/-/cjs-module-lexer-1.3.1.tgz#c485341ae8fd999ca4ee5af2d7a1c9ae01e0099c"
   integrity sha512-a3KdPAANPbNE4ZUv9h6LckSl9zLsYOP4MBmhIPkRaeyybt+r4UghLvq+xw/YwUcC1gqylCkL4rdVs3Lwupjm4Q==
-
-confbox@^0.1.7:
-  version "0.1.7"
-  resolved "https://registry.yarnpkg.com/confbox/-/confbox-0.1.7.tgz#ccfc0a2bcae36a84838e83a3b7f770fb17d6c579"
-  integrity sha512-uJcB/FKZtBMCJpK8MQji6bJHgu1tixKPxRLeGkNzBoOZzpnZUJm0jm2/sBDWcuBx1dYgxV4JU+g5hmNxCyAmdA==
 
 consola@^3.2.3:
   version "3.2.3"
@@ -647,19 +663,24 @@ date-fns@^3.6.0:
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-3.6.0.tgz#f20ca4fe94f8b754951b24240676e8618c0206bf"
   integrity sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==
 
-debug@^4.3.1, debug@^4.3.4:
+debug@^4.3.1:
   version "4.3.5"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.5.tgz#e83444eceb9fedd4a1da56d671ae2446a01a6e1e"
   integrity sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==
   dependencies:
     ms "2.1.2"
 
-deep-eql@^4.1.3:
-  version "4.1.4"
-  resolved "https://registry.yarnpkg.com/deep-eql/-/deep-eql-4.1.4.tgz#d0d3912865911bb8fac5afb4e3acfa6a28dc72b7"
-  integrity sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==
+debug@^4.3.5:
+  version "4.3.6"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.6.tgz#2ab2c38fbaffebf8aa95fdfe6d88438c7a13c52b"
+  integrity sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==
   dependencies:
-    type-detect "^4.0.0"
+    ms "2.1.2"
+
+deep-eql@^5.0.1:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/deep-eql/-/deep-eql-5.0.2.tgz#4b756d8d770a9257300825d52a2c2cff99c3a341"
+  integrity sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==
 
 defu@^6.1.4:
   version "6.1.4"
@@ -670,11 +691,6 @@ devalue@^4.3.0:
   version "4.3.3"
   resolved "https://registry.yarnpkg.com/devalue/-/devalue-4.3.3.tgz#e35df3bdc49136837e77986f629b9fa6fef50726"
   integrity sha512-UH8EL6H2ifcY8TbD2QsxwCC/pr5xSwPvv85LrLXVihmHVC3T3YqTCIwnR5ak0yO1KYqlxrPVOA/JVZJYPy2ATg==
-
-diff-sequences@^29.6.3:
-  version "29.6.3"
-  resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-29.6.3.tgz#4deaf894d11407c51efc8418012f9e70b84ea921"
-  integrity sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==
 
 esbuild@0.17.19:
   version "0.17.19"
@@ -787,7 +803,7 @@ function-bind@^1.1.2:
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.2.tgz#2c02d864d97f3ea6c8830c464cbd11ab6eab7a1c"
   integrity sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==
 
-get-func-name@^2.0.1, get-func-name@^2.0.2:
+get-func-name@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/get-func-name/-/get-func-name-2.0.2.tgz#0d7cf20cd13fda808669ffa88f4ffc7a3943fc41"
   integrity sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==
@@ -875,23 +891,10 @@ itty-router@^5.0.17:
   resolved "https://registry.yarnpkg.com/itty-router/-/itty-router-5.0.17.tgz#e5a015756bfc420ea20f09da80935a7feb8c4ef8"
   integrity sha512-ZHnPI0OOyTTLuNp2FdciejYaK4Wl3ZV3O0yEm8njOGggh/k/ek3BL7X2I5YsCOfc5vLhIJgj3Z4pUtLs6k9Ucg==
 
-js-tokens@^9.0.0:
-  version "9.0.0"
-  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-9.0.0.tgz#0f893996d6f3ed46df7f0a3b12a03f5fd84223c1"
-  integrity sha512-WriZw1luRMlmV3LGJaR6QOJjWwgLUTf89OwT2lUOyjX2dJGBwgmIkbcz+7WFZjrZM635JOIR517++e/67CP9dQ==
-
-local-pkg@^0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/local-pkg/-/local-pkg-0.5.0.tgz#093d25a346bae59a99f80e75f6e9d36d7e8c925c"
-  integrity sha512-ok6z3qlYyCDS4ZEU27HaU6x/xZa9Whf8jD4ptH5UZTQYZVYeb9bnZ3ojVhiJNLiXK1Hfc0GNbLXcmZ5plLDDBg==
-  dependencies:
-    mlly "^1.4.2"
-    pkg-types "^1.0.3"
-
-loupe@^2.3.6, loupe@^2.3.7:
-  version "2.3.7"
-  resolved "https://registry.yarnpkg.com/loupe/-/loupe-2.3.7.tgz#6e69b7d4db7d3ab436328013d37d1c8c3540c697"
-  integrity sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==
+loupe@^3.1.0, loupe@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/loupe/-/loupe-3.1.1.tgz#71d038d59007d890e3247c5db97c1ec5a92edc54"
+  integrity sha512-edNu/8D5MKVfGVFRhFf8aAxiTM6Wumfz5XsaatSxlD3w4R1d/WEKUTydCdPGbl9K7QG/Ca3GnDV2sIKIpXRQcw==
   dependencies:
     get-func-name "^2.0.1"
 
@@ -902,12 +905,12 @@ magic-string@^0.25.3:
   dependencies:
     sourcemap-codec "^1.4.8"
 
-magic-string@^0.30.5:
-  version "0.30.10"
-  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.30.10.tgz#123d9c41a0cb5640c892b041d4cfb3bd0aa4b39e"
-  integrity sha512-iIRwTIf0QKV3UAnYK4PU8uiEc4SRh5jX0mwpIwETPpHdhVM4f53RSwS/vXvN1JhGX+Cs7B8qIq3d6AH49O5fAQ==
+magic-string@^0.30.10:
+  version "0.30.11"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.30.11.tgz#301a6f93b3e8c2cb13ac1a7a673492c0dfd12954"
+  integrity sha512-+Wri9p0QHMy+545hKww7YAu5NyzF8iomPL/RQazugQ9+Ez4Ic3mERMd8ZTX5rfK944j+560ZJi8iAwgak1Ac7A==
   dependencies:
-    "@jridgewell/sourcemap-codec" "^1.4.15"
+    "@jridgewell/sourcemap-codec" "^1.5.0"
 
 merge-stream@^2.0.0:
   version "2.0.0"
@@ -942,10 +945,10 @@ miniflare@3.20240701.0:
     youch "^3.2.2"
     zod "^3.22.3"
 
-miniflare@3.20240718.1:
-  version "3.20240718.1"
-  resolved "https://registry.yarnpkg.com/miniflare/-/miniflare-3.20240718.1.tgz#26ccb95be087cd99cd478dbf2e3a3d40f231bf45"
-  integrity sha512-mn3MjGnpgYvarCRTfz4TQyVyY8yW0zz7f8LOAPVai78IGC/lcVcyskZcuIr7Zovb2i+IERmmsJAiEPeZHIIKbA==
+miniflare@3.20240806.1:
+  version "3.20240806.1"
+  resolved "https://registry.yarnpkg.com/miniflare/-/miniflare-3.20240806.1.tgz#e0d8bbe4889a3e5fbf055038021faf910f0be4cf"
+  integrity sha512-wJq3YQYx9k83L2CNYtxvwWvXSi+uHrC6aFoXYSbzhxIDlUWvMEqippj+3HeKLgsggC31nHJab3b1Pifg9IxIFQ==
   dependencies:
     "@cspotcode/source-map-support" "0.8.1"
     acorn "^8.8.0"
@@ -955,20 +958,10 @@ miniflare@3.20240718.1:
     glob-to-regexp "^0.4.1"
     stoppable "^1.1.0"
     undici "^5.28.4"
-    workerd "1.20240718.0"
+    workerd "1.20240806.0"
     ws "^8.17.1"
     youch "^3.2.2"
     zod "^3.22.3"
-
-mlly@^1.4.2, mlly@^1.7.1:
-  version "1.7.1"
-  resolved "https://registry.yarnpkg.com/mlly/-/mlly-1.7.1.tgz#e0336429bb0731b6a8e887b438cbdae522c8f32f"
-  integrity sha512-rrVRZRELyQzrIUAVMHxP97kv+G786pHmOKzuFII8zDYahFBS7qnHh2AlYSl1GAHhaMPCz6/oHjVMcfFYgFYHgA==
-  dependencies:
-    acorn "^8.11.3"
-    pathe "^1.1.2"
-    pkg-types "^1.1.1"
-    ufo "^1.5.3"
 
 ms@2.1.2:
   version "2.1.2"
@@ -1014,13 +1007,6 @@ onetime@^6.0.0:
   dependencies:
     mimic-fn "^4.0.0"
 
-p-limit@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-5.0.0.tgz#6946d5b7140b649b7a33a027d89b4c625b3a5985"
-  integrity sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==
-  dependencies:
-    yocto-queue "^1.0.0"
-
 path-key@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-3.1.1.tgz#581f6ade658cbba65a0d3380de7753295054f375"
@@ -1041,17 +1027,17 @@ path-to-regexp@^6.2.0:
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-6.2.2.tgz#324377a83e5049cbecadc5554d6a63a9a4866b36"
   integrity sha512-GQX3SSMokngb36+whdpRXE+3f9V8UzyAorlYvOGx87ufGHehNTn5lCxrKtLyZ4Yl/wEKnNnr98ZzOwwDZV5ogw==
 
-pathe@^1.1.1, pathe@^1.1.2:
+pathe@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/pathe/-/pathe-1.1.2.tgz#6c4cb47a945692e48a1ddd6e4094d170516437ec"
   integrity sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==
 
-pathval@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/pathval/-/pathval-1.1.1.tgz#8534e77a77ce7ac5a2512ea21e0fdb8fcf6c3d8d"
-  integrity sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==
+pathval@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/pathval/-/pathval-2.0.0.tgz#7e2550b422601d4f6b8e26f1301bc8f15a741a25"
+  integrity sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA==
 
-picocolors@^1.0.0, picocolors@^1.0.1:
+picocolors@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.0.1.tgz#a8ad579b571952f0e5d25892de5445bcfe25aaa1"
   integrity sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==
@@ -1060,15 +1046,6 @@ picomatch@^2.0.4, picomatch@^2.2.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
-
-pkg-types@^1.0.3, pkg-types@^1.1.1:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/pkg-types/-/pkg-types-1.1.3.tgz#161bb1242b21daf7795036803f28e30222e476e3"
-  integrity sha512-+JrgthZG6m3ckicaOB74TwQ+tBWsFl3qVQg7mN8ulwSOElJ7gBhKzj2VkCPnZ4NlF6kEquYU+RIYNVAvzd54UA==
-  dependencies:
-    confbox "^0.1.7"
-    mlly "^1.7.1"
-    pathe "^1.1.2"
 
 postcss@^8.4.39:
   version "8.4.39"
@@ -1084,24 +1061,10 @@ prettier@3.3.3:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.3.3.tgz#30c54fe0be0d8d12e6ae61dbb10109ea00d53105"
   integrity sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==
 
-pretty-format@^29.7.0:
-  version "29.7.0"
-  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-29.7.0.tgz#ca42c758310f365bfa71a0bda0a807160b776812"
-  integrity sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==
-  dependencies:
-    "@jest/schemas" "^29.6.3"
-    ansi-styles "^5.0.0"
-    react-is "^18.0.0"
-
 printable-characters@^1.0.42:
   version "1.0.42"
   resolved "https://registry.yarnpkg.com/printable-characters/-/printable-characters-1.0.42.tgz#3f18e977a9bd8eb37fcc4ff5659d7be90868b3d8"
   integrity sha512-dKp+C4iXWK4vVYZmYSd0KBH5F/h1HoZRsbJ82AVKRO3PEo8L4lBS/vLwhVtpwwuYcoIsVY+1JYKR268yn480uQ==
-
-react-is@^18.0.0:
-  version "18.3.1"
-  resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.3.1.tgz#e83557dc12eae63a99e003a46388b1dcbb44db7e"
-  integrity sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==
 
 readdirp@~3.6.0:
   version "3.6.0"
@@ -1235,7 +1198,7 @@ stacktracey@^2.1.8:
     as-table "^1.0.36"
     get-source "^2.0.12"
 
-std-env@^3.5.0:
+std-env@^3.7.0:
   version "3.7.0"
   resolved "https://registry.yarnpkg.com/std-env/-/std-env-3.7.0.tgz#c9f7386ced6ecf13360b6c6c55b8aaa4ef7481d2"
   integrity sha512-JPbdCEQLj1w5GilpiHAx3qJvFndqybBysA3qUOnznweH4QbNYUsW/ea8QzSrnh0vNsezMMw5bcVool8lM0gwzg==
@@ -1250,32 +1213,30 @@ strip-final-newline@^3.0.0:
   resolved "https://registry.yarnpkg.com/strip-final-newline/-/strip-final-newline-3.0.0.tgz#52894c313fbff318835280aed60ff71ebf12b8fd"
   integrity sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==
 
-strip-literal@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/strip-literal/-/strip-literal-2.1.0.tgz#6d82ade5e2e74f5c7e8739b6c84692bd65f0bd2a"
-  integrity sha512-Op+UycaUt/8FbN/Z2TWPBLge3jWrP3xj10f3fnYxf052bKuS3EKs1ZQcVGjnEMdsNVAM+plXRdmjrZ/KgG3Skw==
-  dependencies:
-    js-tokens "^9.0.0"
-
 supports-preserve-symlinks-flag@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
 
-tinybench@^2.5.1:
-  version "2.8.0"
-  resolved "https://registry.yarnpkg.com/tinybench/-/tinybench-2.8.0.tgz#30e19ae3a27508ee18273ffed9ac7018949acd7b"
-  integrity sha512-1/eK7zUnIklz4JUUlL+658n58XO2hHLQfSk1Zf2LKieUjxidN16eKFEoDEfjHc3ohofSSqK3X5yO6VGb6iW8Lw==
+tinybench@^2.8.0:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/tinybench/-/tinybench-2.9.0.tgz#103c9f8ba6d7237a47ab6dd1dcff77251863426b"
+  integrity sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==
 
-tinypool@^0.8.3:
-  version "0.8.4"
-  resolved "https://registry.yarnpkg.com/tinypool/-/tinypool-0.8.4.tgz#e217fe1270d941b39e98c625dcecebb1408c9aa8"
-  integrity sha512-i11VH5gS6IFeLY3gMBQ00/MmLncVP7JLXOw1vlgkytLmJK7QnEr7NXf0LBdxfmNPAeyetukOk0bOYrJrFGjYJQ==
+tinypool@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/tinypool/-/tinypool-1.0.0.tgz#a68965218e04f4ad9de037d2a1cd63cda9afb238"
+  integrity sha512-KIKExllK7jp3uvrNtvRBYBWBOAXSX8ZvoaD8T+7KB/QHIuoJW3Pmr60zucywjAlMb5TeXUkcs/MWeWLu0qvuAQ==
 
-tinyspy@^2.2.0:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/tinyspy/-/tinyspy-2.2.1.tgz#117b2342f1f38a0dbdcc73a50a454883adf861d1"
-  integrity sha512-KYad6Vy5VDWV4GH3fjpseMQ/XU2BhIYP7Vzd0LG44qRWm/Yt2WCOTicFdvmgo6gWaqooMQCawTtILVQJupKu7A==
+tinyrainbow@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/tinyrainbow/-/tinyrainbow-1.2.0.tgz#5c57d2fc0fb3d1afd78465c33ca885d04f02abb5"
+  integrity sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==
+
+tinyspy@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/tinyspy/-/tinyspy-3.0.0.tgz#cb61644f2713cd84dee184863f4642e06ddf0585"
+  integrity sha512-q5nmENpTHgiPVd1cJDDc9cVoYN5x4vCvwT3FMilvKPKneCBZAxn2YWQjDF0UMcE9k0Cay1gBiDfTMU0g+mPMQA==
 
 to-regex-range@^5.0.1:
   version "5.0.1"
@@ -1289,15 +1250,10 @@ tslib@^2.2.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.3.tgz#0438f810ad7a9edcde7a241c3d80db693c8cbfe0"
   integrity sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==
 
-type-detect@^4.0.0, type-detect@^4.0.8:
-  version "4.0.8"
-  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
-  integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
-
-typescript@^5.5.2:
-  version "5.5.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.5.3.tgz#e1b0a3c394190838a0b168e771b0ad56a0af0faa"
-  integrity sha512-/hreyEujaB0w76zKo6717l3L0o/qEUtRgdvUBvlkhoWeOVMjMuHNHk0BRBzikzuGDqNmPQbg5ifMEqsHLiIUcQ==
+typescript@^5.5.4:
+  version "5.5.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.5.4.tgz#d9852d6c82bad2d2eda4fd74a5762a8f5909e9ba"
+  integrity sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==
 
 ufo@^1.5.3:
   version "1.5.3"
@@ -1328,15 +1284,15 @@ undici@^5.28.4:
     pathe "^1.1.2"
     ufo "^1.5.3"
 
-vite-node@1.5.0:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/vite-node/-/vite-node-1.5.0.tgz#7f74dadfecb15bca016c5ce5ef85e5cc4b82abf2"
-  integrity sha512-tV8h6gMj6vPzVCa7l+VGq9lwoJjW8Y79vst8QZZGiuRAfijU+EEWuc0kFpmndQrWhMMhet1jdSF+40KSZUqIIw==
+vite-node@2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/vite-node/-/vite-node-2.0.5.tgz#36d909188fc6e3aba3da5fc095b3637d0d18e27b"
+  integrity sha512-LdsW4pxj0Ot69FAoXZ1yTnA9bjGohr2yNBU7QKRxpz8ITSkhuDl6h3zS/tvgz4qrNjeRnvrWeXQ8ZF7Um4W00Q==
   dependencies:
     cac "^6.7.14"
-    debug "^4.3.4"
-    pathe "^1.1.1"
-    picocolors "^1.0.0"
+    debug "^4.3.5"
+    pathe "^1.1.2"
+    tinyrainbow "^1.2.0"
     vite "^5.0.0"
 
 vite@^5.0.0:
@@ -1350,31 +1306,30 @@ vite@^5.0.0:
   optionalDependencies:
     fsevents "~2.3.3"
 
-vitest@1.5.0:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/vitest/-/vitest-1.5.0.tgz#6ebb396bd358650011a9c96c18fa614b668365c1"
-  integrity sha512-d8UKgR0m2kjdxDWX6911uwxout6GHS0XaGH1cksSIVVG8kRlE7G7aBw7myKQCvDI5dT4j7ZMa+l706BIORMDLw==
+vitest@2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/vitest/-/vitest-2.0.5.tgz#2f15a532704a7181528e399cc5b754c7f335fd62"
+  integrity sha512-8GUxONfauuIdeSl5f9GTgVEpg5BTOlplET4WEDaeY2QBiN8wSm68vxN/tb5z405OwppfoCavnwXafiaYBC/xOA==
   dependencies:
-    "@vitest/expect" "1.5.0"
-    "@vitest/runner" "1.5.0"
-    "@vitest/snapshot" "1.5.0"
-    "@vitest/spy" "1.5.0"
-    "@vitest/utils" "1.5.0"
-    acorn-walk "^8.3.2"
-    chai "^4.3.10"
-    debug "^4.3.4"
+    "@ampproject/remapping" "^2.3.0"
+    "@vitest/expect" "2.0.5"
+    "@vitest/pretty-format" "^2.0.5"
+    "@vitest/runner" "2.0.5"
+    "@vitest/snapshot" "2.0.5"
+    "@vitest/spy" "2.0.5"
+    "@vitest/utils" "2.0.5"
+    chai "^5.1.1"
+    debug "^4.3.5"
     execa "^8.0.1"
-    local-pkg "^0.5.0"
-    magic-string "^0.30.5"
-    pathe "^1.1.1"
-    picocolors "^1.0.0"
-    std-env "^3.5.0"
-    strip-literal "^2.0.0"
-    tinybench "^2.5.1"
-    tinypool "^0.8.3"
+    magic-string "^0.30.10"
+    pathe "^1.1.2"
+    std-env "^3.7.0"
+    tinybench "^2.8.0"
+    tinypool "^1.0.0"
+    tinyrainbow "^1.2.0"
     vite "^5.0.0"
-    vite-node "1.5.0"
-    why-is-node-running "^2.2.2"
+    vite-node "2.0.5"
+    why-is-node-running "^2.3.0"
 
 which@^2.0.1:
   version "2.0.2"
@@ -1383,7 +1338,7 @@ which@^2.0.1:
   dependencies:
     isexe "^2.0.0"
 
-why-is-node-running@^2.2.2:
+why-is-node-running@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/why-is-node-running/-/why-is-node-running-2.3.0.tgz#a3f69a97107f494b3cdc3bdddd883a7d65cebf04"
   integrity sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==
@@ -1402,16 +1357,16 @@ workerd@1.20240701.0:
     "@cloudflare/workerd-linux-arm64" "1.20240701.0"
     "@cloudflare/workerd-windows-64" "1.20240701.0"
 
-workerd@1.20240718.0:
-  version "1.20240718.0"
-  resolved "https://registry.yarnpkg.com/workerd/-/workerd-1.20240718.0.tgz#7a397d0a159f7362dc3f7b19472190a858d96f7c"
-  integrity sha512-w7lOLRy0XecQTg/ujTLWBiJJuoQvzB3CdQ6/8Wgex3QxFhV9Pbnh3UbwIuUfMw3OCCPQc4o7y+1P+mISAgp6yg==
+workerd@1.20240806.0:
+  version "1.20240806.0"
+  resolved "https://registry.yarnpkg.com/workerd/-/workerd-1.20240806.0.tgz#7a517a7967c9e620c89edb8b16aa5c84f91bda48"
+  integrity sha512-yyNtyzTMgVY0sgYijHBONqZFVXsOFGj2jDjS8MF/RbO2ZdGROvs4Hkc/9QnmqFWahE0STxXeJ1yW1yVotdF0UQ==
   optionalDependencies:
-    "@cloudflare/workerd-darwin-64" "1.20240718.0"
-    "@cloudflare/workerd-darwin-arm64" "1.20240718.0"
-    "@cloudflare/workerd-linux-64" "1.20240718.0"
-    "@cloudflare/workerd-linux-arm64" "1.20240718.0"
-    "@cloudflare/workerd-windows-64" "1.20240718.0"
+    "@cloudflare/workerd-darwin-64" "1.20240806.0"
+    "@cloudflare/workerd-darwin-arm64" "1.20240806.0"
+    "@cloudflare/workerd-linux-64" "1.20240806.0"
+    "@cloudflare/workerd-linux-arm64" "1.20240806.0"
+    "@cloudflare/workerd-windows-64" "1.20240806.0"
 
 wrangler@3.64.0:
   version "3.64.0"
@@ -1437,19 +1392,20 @@ wrangler@3.64.0:
   optionalDependencies:
     fsevents "~2.3.2"
 
-wrangler@^3.67.1:
-  version "3.67.1"
-  resolved "https://registry.yarnpkg.com/wrangler/-/wrangler-3.67.1.tgz#c9bb344b70c8c2106ad33f03beaa063dd5b49526"
-  integrity sha512-lLVJxq/OZMfntvZ79WQJNC1OKfxOCs6PLfogqDBuPFEQ3L/Mwqvd9IZ0bB8ahrwUN/K3lSdDPXynk9HfcGZxVw==
+wrangler@^3.72.0:
+  version "3.72.0"
+  resolved "https://registry.yarnpkg.com/wrangler/-/wrangler-3.72.0.tgz#27c2863e6dfb89f7f849b0644e96a988f1b63415"
+  integrity sha512-9sryHTCtCj48vUC5y/M3Dsx02U1bT6mK9E41TXBCpSJgWh8UvWG/xgmu2dY93Mqj9aJIvK/kwwIBRlNFRwF7Hw==
   dependencies:
     "@cloudflare/kv-asset-handler" "0.3.4"
+    "@cloudflare/workers-shared" "0.2.0"
     "@esbuild-plugins/node-globals-polyfill" "^0.2.3"
     "@esbuild-plugins/node-modules-polyfill" "^0.2.2"
     blake3-wasm "^2.1.5"
     chokidar "^3.5.3"
     date-fns "^3.6.0"
     esbuild "0.17.19"
-    miniflare "3.20240718.1"
+    miniflare "3.20240806.1"
     nanoid "^3.3.3"
     path-to-regexp "^6.2.0"
     resolve "^1.22.8"
@@ -1457,7 +1413,7 @@ wrangler@^3.67.1:
     selfsigned "^2.0.1"
     source-map "^0.6.1"
     unenv "npm:unenv-nightly@1.10.0-1717606461.a117952"
-    workerd "1.20240718.0"
+    workerd "1.20240806.0"
     xxhash-wasm "^1.0.1"
   optionalDependencies:
     fsevents "~2.3.2"
@@ -1471,11 +1427,6 @@ xxhash-wasm@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/xxhash-wasm/-/xxhash-wasm-1.0.2.tgz#ecc0f813219b727af4d5f3958ca6becee2f2f1ff"
   integrity sha512-ibF0Or+FivM9lNrg+HGJfVX8WJqgo+kCLDc4vx6xMeTce7Aj+DLttKbxxRR/gNLSAelRc1omAPlJ77N/Jem07A==
-
-yocto-queue@^1.0.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-1.1.1.tgz#fef65ce3ac9f8a32ceac5a634f74e17e5b232110"
-  integrity sha512-b4JR1PFR10y1mKjhHY9LaGo6tmrgjit7hxVIeAmyMw3jegXR4dhYqLaQF5zMXZxY7tLpMyJeLjr1C4rLmkVe8g==
 
 youch@^3.2.2:
   version "3.3.3"

--- a/cloudflare-workers/yarn.lock
+++ b/cloudflare-workers/yarn.lock
@@ -2,14 +2,6 @@
 # yarn lockfile v1
 
 
-"@ampproject/remapping@^2.3.0":
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/@ampproject/remapping/-/remapping-2.3.0.tgz#ed441b6fa600072520ce18b43d2c8cc8caecc7f4"
-  integrity sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==
-  dependencies:
-    "@jridgewell/gen-mapping" "^0.3.5"
-    "@jridgewell/trace-mapping" "^0.3.24"
-
 "@cloudflare/kv-asset-handler@0.3.4":
   version "0.3.4"
   resolved "https://registry.yarnpkg.com/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.3.4.tgz#5cc152847c8ae4d280ec5d7f4f6ba8c976b585c3"
@@ -341,26 +333,19 @@
   resolved "https://registry.yarnpkg.com/@fastify/busboy/-/busboy-2.1.1.tgz#b9da6a878a371829a0502c9b6c1c143ef6663f4d"
   integrity sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==
 
-"@jridgewell/gen-mapping@^0.3.5":
-  version "0.3.5"
-  resolved "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz#dcce6aff74bdf6dad1a95802b69b04a2fcb1fb36"
-  integrity sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==
+"@jest/schemas@^29.6.3":
+  version "29.6.3"
+  resolved "https://registry.yarnpkg.com/@jest/schemas/-/schemas-29.6.3.tgz#430b5ce8a4e0044a7e3819663305a7b3091c8e03"
+  integrity sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==
   dependencies:
-    "@jridgewell/set-array" "^1.2.1"
-    "@jridgewell/sourcemap-codec" "^1.4.10"
-    "@jridgewell/trace-mapping" "^0.3.24"
+    "@sinclair/typebox" "^0.27.8"
 
-"@jridgewell/resolve-uri@^3.0.3", "@jridgewell/resolve-uri@^3.1.0":
+"@jridgewell/resolve-uri@^3.0.3":
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz#7a0ee601f60f99a20c7c7c5ff0c80388c1189bd6"
   integrity sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==
 
-"@jridgewell/set-array@^1.2.1":
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/@jridgewell/set-array/-/set-array-1.2.1.tgz#558fb6472ed16a4c850b889530e6b36438c49280"
-  integrity sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==
-
-"@jridgewell/sourcemap-codec@^1.4.10", "@jridgewell/sourcemap-codec@^1.4.14", "@jridgewell/sourcemap-codec@^1.5.0":
+"@jridgewell/sourcemap-codec@^1.4.10", "@jridgewell/sourcemap-codec@^1.5.0":
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz#3188bcb273a414b0d215fd22a58540b989b9409a"
   integrity sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==
@@ -372,14 +357,6 @@
   dependencies:
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
-
-"@jridgewell/trace-mapping@^0.3.24":
-  version "0.3.25"
-  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz#15f190e98895f3fc23276ee14bc76b675c2e50f0"
-  integrity sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==
-  dependencies:
-    "@jridgewell/resolve-uri" "^3.1.0"
-    "@jridgewell/sourcemap-codec" "^1.4.14"
 
 "@rollup/rollup-android-arm-eabi@4.18.1":
   version "4.18.1"
@@ -461,6 +438,11 @@
   resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.18.1.tgz#0cb240c147c0dfd0e3eaff4cc060a772d39e155c"
   integrity sha512-yjk2MAkQmoaPYCSu35RLJ62+dz358nE83VfTePJRp8CG7aMg25mEJYpXFiD+NcevhX8LxD5OP5tktPXnXN7GDw==
 
+"@sinclair/typebox@^0.27.8":
+  version "0.27.8"
+  resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.27.8.tgz#6667fac16c436b5434a387a34dedb013198f6e6e"
+  integrity sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==
+
 "@types/estree@1.0.5", "@types/estree@^1.0.0":
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.5.tgz#a6ce3e556e00fd9895dd872dd172ad0d4bd687f4"
@@ -480,68 +462,66 @@
   dependencies:
     undici-types "~5.26.4"
 
-"@vitest/expect@2.0.5":
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/@vitest/expect/-/expect-2.0.5.tgz#f3745a6a2c18acbea4d39f5935e913f40d26fa86"
-  integrity sha512-yHZtwuP7JZivj65Gxoi8upUN2OzHTi3zVfjwdpu2WrvCZPLwsJ2Ey5ILIPccoW23dd/zQBlJ4/dhi7DWNyXCpA==
+"@vitest/expect@1.5.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@vitest/expect/-/expect-1.5.0.tgz#961190510a2723bd4abf5540bcec0a4dfd59ef14"
+  integrity sha512-0pzuCI6KYi2SIC3LQezmxujU9RK/vwC1U9R0rLuGlNGcOuDWxqWKu6nUdFsX9tH1WU0SXtAxToOsEjeUn1s3hA==
   dependencies:
-    "@vitest/spy" "2.0.5"
-    "@vitest/utils" "2.0.5"
-    chai "^5.1.1"
-    tinyrainbow "^1.2.0"
+    "@vitest/spy" "1.5.0"
+    "@vitest/utils" "1.5.0"
+    chai "^4.3.10"
 
-"@vitest/pretty-format@2.0.5", "@vitest/pretty-format@^2.0.5":
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/@vitest/pretty-format/-/pretty-format-2.0.5.tgz#91d2e6d3a7235c742e1a6cc50e7786e2f2979b1e"
-  integrity sha512-h8k+1oWHfwTkyTkb9egzwNMfJAEx4veaPSnMeKbVSjp4euqGSbQlm5+6VHwTr7u4FJslVVsUG5nopCaAYdOmSQ==
+"@vitest/runner@1.5.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@vitest/runner/-/runner-1.5.0.tgz#1f7cb78ee4064e73e53d503a19c1b211c03dfe0c"
+  integrity sha512-7HWwdxXP5yDoe7DTpbif9l6ZmDwCzcSIK38kTSIt6CFEpMjX4EpCgT6wUmS0xTXqMI6E/ONmfgRKmaujpabjZQ==
   dependencies:
-    tinyrainbow "^1.2.0"
+    "@vitest/utils" "1.5.0"
+    p-limit "^5.0.0"
+    pathe "^1.1.1"
 
-"@vitest/runner@2.0.5":
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/@vitest/runner/-/runner-2.0.5.tgz#89197e712bb93513537d6876995a4843392b2a84"
-  integrity sha512-TfRfZa6Bkk9ky4tW0z20WKXFEwwvWhRY+84CnSEtq4+3ZvDlJyY32oNTJtM7AW9ihW90tX/1Q78cb6FjoAs+ig==
+"@vitest/snapshot@1.5.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@vitest/snapshot/-/snapshot-1.5.0.tgz#cd2d611fd556968ce8fb6b356a09b4593c525947"
+  integrity sha512-qpv3fSEuNrhAO3FpH6YYRdaECnnRjg9VxbhdtPwPRnzSfHVXnNzzrpX4cJxqiwgRMo7uRMWDFBlsBq4Cr+rO3A==
   dependencies:
-    "@vitest/utils" "2.0.5"
-    pathe "^1.1.2"
+    magic-string "^0.30.5"
+    pathe "^1.1.1"
+    pretty-format "^29.7.0"
 
-"@vitest/snapshot@2.0.5":
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/@vitest/snapshot/-/snapshot-2.0.5.tgz#a2346bc5013b73c44670c277c430e0334690a162"
-  integrity sha512-SgCPUeDFLaM0mIUHfaArq8fD2WbaXG/zVXjRupthYfYGzc8ztbFbu6dUNOblBG7XLMR1kEhS/DNnfCZ2IhdDew==
+"@vitest/spy@1.5.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@vitest/spy/-/spy-1.5.0.tgz#1369a1bec47f46f18eccfa45f1e8fbb9b5e15e77"
+  integrity sha512-vu6vi6ew5N5MMHJjD5PoakMRKYdmIrNJmyfkhRpQt5d9Ewhw9nZ5Aqynbi3N61bvk9UvZ5UysMT6ayIrZ8GA9w==
   dependencies:
-    "@vitest/pretty-format" "2.0.5"
-    magic-string "^0.30.10"
-    pathe "^1.1.2"
+    tinyspy "^2.2.0"
 
-"@vitest/spy@2.0.5":
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/@vitest/spy/-/spy-2.0.5.tgz#590fc07df84a78b8e9dd976ec2090920084a2b9f"
-  integrity sha512-c/jdthAhvJdpfVuaexSrnawxZz6pywlTPe84LUB2m/4t3rl2fTo9NFGBG4oWgaD+FTgDDV8hJ/nibT7IfH3JfA==
+"@vitest/utils@1.5.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@vitest/utils/-/utils-1.5.0.tgz#90c9951f4516f6d595da24876b58e615f6c99863"
+  integrity sha512-BDU0GNL8MWkRkSRdNFvCUCAVOeHaUlVJ9Tx0TYBZyXaaOTmGtUFObzchCivIBrIwKzvZA7A9sCejVhXM2aY98A==
   dependencies:
-    tinyspy "^3.0.0"
-
-"@vitest/utils@2.0.5":
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/@vitest/utils/-/utils-2.0.5.tgz#6f8307a4b6bc6ceb9270007f73c67c915944e926"
-  integrity sha512-d8HKbqIcya+GR67mkZbrzhS5kKhtp8dQLcmRZLGTscGVg7yImT82cIrhtn2L8+VujWcy6KZweApgNmPsTAO/UQ==
-  dependencies:
-    "@vitest/pretty-format" "2.0.5"
+    diff-sequences "^29.6.3"
     estree-walker "^3.0.3"
-    loupe "^3.1.1"
-    tinyrainbow "^1.2.0"
+    loupe "^2.3.7"
+    pretty-format "^29.7.0"
 
-acorn-walk@^8.2.0:
+acorn-walk@^8.2.0, acorn-walk@^8.3.2:
   version "8.3.3"
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.3.3.tgz#9caeac29eefaa0c41e3d4c65137de4d6f34df43e"
   integrity sha512-MxXdReSRhGO7VlFe1bRG/oI7/mdLV9B9JJT0N8vZOhF7gFRR5l3M8W9G8JxmKV+JC5mGqJ0QvqfSOLsCPa4nUw==
   dependencies:
     acorn "^8.11.0"
 
-acorn@^8.11.0, acorn@^8.8.0:
+acorn@^8.11.0, acorn@^8.11.3, acorn@^8.8.0:
   version "8.12.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.12.1.tgz#71616bdccbe25e27a54439e0046e89ca76df2248"
   integrity sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==
+
+ansi-styles@^5.0.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-5.2.0.tgz#07449690ad45777d1924ac2abb2fc8895dba836b"
+  integrity sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==
 
 anymatch@~3.1.2:
   version "3.1.3"
@@ -558,10 +538,10 @@ as-table@^1.0.36:
   dependencies:
     printable-characters "^1.0.42"
 
-assertion-error@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-2.0.1.tgz#f641a196b335690b1070bf00b6e7593fec190bf7"
-  integrity sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==
+assertion-error@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-1.1.0.tgz#e60b6b0e8f301bd97e5375215bda406c85118c0b"
+  integrity sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==
 
 binary-extensions@^2.0.0:
   version "2.3.0"
@@ -598,21 +578,25 @@ capnp-ts@^0.7.0:
     debug "^4.3.1"
     tslib "^2.2.0"
 
-chai@^5.1.1:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/chai/-/chai-5.1.1.tgz#f035d9792a22b481ead1c65908d14bb62ec1c82c"
-  integrity sha512-pT1ZgP8rPNqUgieVaEY+ryQr6Q4HXNg8Ei9UnLUrjN4IA7dvQC5JB+/kxVcPNDHyBcc/26CXPkbNzq3qwrOEKA==
+chai@^4.3.10:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/chai/-/chai-4.5.0.tgz#707e49923afdd9b13a8b0b47d33d732d13812fd8"
+  integrity sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==
   dependencies:
-    assertion-error "^2.0.1"
-    check-error "^2.1.1"
-    deep-eql "^5.0.1"
-    loupe "^3.1.0"
-    pathval "^2.0.0"
+    assertion-error "^1.1.0"
+    check-error "^1.0.3"
+    deep-eql "^4.1.3"
+    get-func-name "^2.0.2"
+    loupe "^2.3.6"
+    pathval "^1.1.1"
+    type-detect "^4.1.0"
 
-check-error@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/check-error/-/check-error-2.1.1.tgz#87eb876ae71ee388fa0471fe423f494be1d96ccc"
-  integrity sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==
+check-error@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/check-error/-/check-error-1.0.3.tgz#a6502e4312a7ee969f646e83bb3ddd56281bd694"
+  integrity sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==
+  dependencies:
+    get-func-name "^2.0.2"
 
 chokidar@^3.5.3:
   version "3.6.0"
@@ -633,6 +617,11 @@ cjs-module-lexer@^1.2.3:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/cjs-module-lexer/-/cjs-module-lexer-1.3.1.tgz#c485341ae8fd999ca4ee5af2d7a1c9ae01e0099c"
   integrity sha512-a3KdPAANPbNE4ZUv9h6LckSl9zLsYOP4MBmhIPkRaeyybt+r4UghLvq+xw/YwUcC1gqylCkL4rdVs3Lwupjm4Q==
+
+confbox@^0.1.7:
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/confbox/-/confbox-0.1.7.tgz#ccfc0a2bcae36a84838e83a3b7f770fb17d6c579"
+  integrity sha512-uJcB/FKZtBMCJpK8MQji6bJHgu1tixKPxRLeGkNzBoOZzpnZUJm0jm2/sBDWcuBx1dYgxV4JU+g5hmNxCyAmdA==
 
 consola@^3.2.3:
   version "3.2.3"
@@ -670,17 +659,19 @@ debug@^4.3.1:
   dependencies:
     ms "2.1.2"
 
-debug@^4.3.5:
+debug@^4.3.4:
   version "4.3.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.6.tgz#2ab2c38fbaffebf8aa95fdfe6d88438c7a13c52b"
   integrity sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==
   dependencies:
     ms "2.1.2"
 
-deep-eql@^5.0.1:
-  version "5.0.2"
-  resolved "https://registry.yarnpkg.com/deep-eql/-/deep-eql-5.0.2.tgz#4b756d8d770a9257300825d52a2c2cff99c3a341"
-  integrity sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==
+deep-eql@^4.1.3:
+  version "4.1.4"
+  resolved "https://registry.yarnpkg.com/deep-eql/-/deep-eql-4.1.4.tgz#d0d3912865911bb8fac5afb4e3acfa6a28dc72b7"
+  integrity sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==
+  dependencies:
+    type-detect "^4.0.0"
 
 defu@^6.1.4:
   version "6.1.4"
@@ -691,6 +682,11 @@ devalue@^4.3.0:
   version "4.3.3"
   resolved "https://registry.yarnpkg.com/devalue/-/devalue-4.3.3.tgz#e35df3bdc49136837e77986f629b9fa6fef50726"
   integrity sha512-UH8EL6H2ifcY8TbD2QsxwCC/pr5xSwPvv85LrLXVihmHVC3T3YqTCIwnR5ak0yO1KYqlxrPVOA/JVZJYPy2ATg==
+
+diff-sequences@^29.6.3:
+  version "29.6.3"
+  resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-29.6.3.tgz#4deaf894d11407c51efc8418012f9e70b84ea921"
+  integrity sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==
 
 esbuild@0.17.19:
   version "0.17.19"
@@ -803,7 +799,7 @@ function-bind@^1.1.2:
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.2.tgz#2c02d864d97f3ea6c8830c464cbd11ab6eab7a1c"
   integrity sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==
 
-get-func-name@^2.0.1:
+get-func-name@^2.0.1, get-func-name@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/get-func-name/-/get-func-name-2.0.2.tgz#0d7cf20cd13fda808669ffa88f4ffc7a3943fc41"
   integrity sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==
@@ -891,10 +887,23 @@ itty-router@^5.0.17:
   resolved "https://registry.yarnpkg.com/itty-router/-/itty-router-5.0.17.tgz#e5a015756bfc420ea20f09da80935a7feb8c4ef8"
   integrity sha512-ZHnPI0OOyTTLuNp2FdciejYaK4Wl3ZV3O0yEm8njOGggh/k/ek3BL7X2I5YsCOfc5vLhIJgj3Z4pUtLs6k9Ucg==
 
-loupe@^3.1.0, loupe@^3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/loupe/-/loupe-3.1.1.tgz#71d038d59007d890e3247c5db97c1ec5a92edc54"
-  integrity sha512-edNu/8D5MKVfGVFRhFf8aAxiTM6Wumfz5XsaatSxlD3w4R1d/WEKUTydCdPGbl9K7QG/Ca3GnDV2sIKIpXRQcw==
+js-tokens@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-9.0.0.tgz#0f893996d6f3ed46df7f0a3b12a03f5fd84223c1"
+  integrity sha512-WriZw1luRMlmV3LGJaR6QOJjWwgLUTf89OwT2lUOyjX2dJGBwgmIkbcz+7WFZjrZM635JOIR517++e/67CP9dQ==
+
+local-pkg@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/local-pkg/-/local-pkg-0.5.0.tgz#093d25a346bae59a99f80e75f6e9d36d7e8c925c"
+  integrity sha512-ok6z3qlYyCDS4ZEU27HaU6x/xZa9Whf8jD4ptH5UZTQYZVYeb9bnZ3ojVhiJNLiXK1Hfc0GNbLXcmZ5plLDDBg==
+  dependencies:
+    mlly "^1.4.2"
+    pkg-types "^1.0.3"
+
+loupe@^2.3.6, loupe@^2.3.7:
+  version "2.3.7"
+  resolved "https://registry.yarnpkg.com/loupe/-/loupe-2.3.7.tgz#6e69b7d4db7d3ab436328013d37d1c8c3540c697"
+  integrity sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==
   dependencies:
     get-func-name "^2.0.1"
 
@@ -905,7 +914,7 @@ magic-string@^0.25.3:
   dependencies:
     sourcemap-codec "^1.4.8"
 
-magic-string@^0.30.10:
+magic-string@^0.30.5:
   version "0.30.11"
   resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.30.11.tgz#301a6f93b3e8c2cb13ac1a7a673492c0dfd12954"
   integrity sha512-+Wri9p0QHMy+545hKww7YAu5NyzF8iomPL/RQazugQ9+Ez4Ic3mERMd8ZTX5rfK944j+560ZJi8iAwgak1Ac7A==
@@ -963,6 +972,16 @@ miniflare@3.20240806.1:
     youch "^3.2.2"
     zod "^3.22.3"
 
+mlly@^1.4.2, mlly@^1.7.1:
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/mlly/-/mlly-1.7.1.tgz#e0336429bb0731b6a8e887b438cbdae522c8f32f"
+  integrity sha512-rrVRZRELyQzrIUAVMHxP97kv+G786pHmOKzuFII8zDYahFBS7qnHh2AlYSl1GAHhaMPCz6/oHjVMcfFYgFYHgA==
+  dependencies:
+    acorn "^8.11.3"
+    pathe "^1.1.2"
+    pkg-types "^1.1.1"
+    ufo "^1.5.3"
+
 ms@2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
@@ -1007,6 +1026,13 @@ onetime@^6.0.0:
   dependencies:
     mimic-fn "^4.0.0"
 
+p-limit@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-5.0.0.tgz#6946d5b7140b649b7a33a027d89b4c625b3a5985"
+  integrity sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==
+  dependencies:
+    yocto-queue "^1.0.0"
+
 path-key@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-3.1.1.tgz#581f6ade658cbba65a0d3380de7753295054f375"
@@ -1027,17 +1053,17 @@ path-to-regexp@^6.2.0:
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-6.2.2.tgz#324377a83e5049cbecadc5554d6a63a9a4866b36"
   integrity sha512-GQX3SSMokngb36+whdpRXE+3f9V8UzyAorlYvOGx87ufGHehNTn5lCxrKtLyZ4Yl/wEKnNnr98ZzOwwDZV5ogw==
 
-pathe@^1.1.2:
+pathe@^1.1.1, pathe@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/pathe/-/pathe-1.1.2.tgz#6c4cb47a945692e48a1ddd6e4094d170516437ec"
   integrity sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==
 
-pathval@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/pathval/-/pathval-2.0.0.tgz#7e2550b422601d4f6b8e26f1301bc8f15a741a25"
-  integrity sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA==
+pathval@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/pathval/-/pathval-1.1.1.tgz#8534e77a77ce7ac5a2512ea21e0fdb8fcf6c3d8d"
+  integrity sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==
 
-picocolors@^1.0.1:
+picocolors@^1.0.0, picocolors@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.0.1.tgz#a8ad579b571952f0e5d25892de5445bcfe25aaa1"
   integrity sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==
@@ -1046,6 +1072,15 @@ picomatch@^2.0.4, picomatch@^2.2.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
+
+pkg-types@^1.0.3, pkg-types@^1.1.1:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/pkg-types/-/pkg-types-1.2.0.tgz#d0268e894e93acff11a6279de147e83354ebd42d"
+  integrity sha512-+ifYuSSqOQ8CqP4MbZA5hDpb97n3E8SVWdJe+Wms9kj745lmd3b7EZJiqvmLwAlmRfjrI7Hi5z3kdBJ93lFNPA==
+  dependencies:
+    confbox "^0.1.7"
+    mlly "^1.7.1"
+    pathe "^1.1.2"
 
 postcss@^8.4.39:
   version "8.4.39"
@@ -1056,15 +1091,29 @@ postcss@^8.4.39:
     picocolors "^1.0.1"
     source-map-js "^1.2.0"
 
-prettier@3.3.3:
+prettier@^3.3.3:
   version "3.3.3"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.3.3.tgz#30c54fe0be0d8d12e6ae61dbb10109ea00d53105"
   integrity sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==
+
+pretty-format@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-29.7.0.tgz#ca42c758310f365bfa71a0bda0a807160b776812"
+  integrity sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==
+  dependencies:
+    "@jest/schemas" "^29.6.3"
+    ansi-styles "^5.0.0"
+    react-is "^18.0.0"
 
 printable-characters@^1.0.42:
   version "1.0.42"
   resolved "https://registry.yarnpkg.com/printable-characters/-/printable-characters-1.0.42.tgz#3f18e977a9bd8eb37fcc4ff5659d7be90868b3d8"
   integrity sha512-dKp+C4iXWK4vVYZmYSd0KBH5F/h1HoZRsbJ82AVKRO3PEo8L4lBS/vLwhVtpwwuYcoIsVY+1JYKR268yn480uQ==
+
+react-is@^18.0.0:
+  version "18.3.1"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.3.1.tgz#e83557dc12eae63a99e003a46388b1dcbb44db7e"
+  integrity sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==
 
 readdirp@~3.6.0:
   version "3.6.0"
@@ -1198,7 +1247,7 @@ stacktracey@^2.1.8:
     as-table "^1.0.36"
     get-source "^2.0.12"
 
-std-env@^3.7.0:
+std-env@^3.5.0:
   version "3.7.0"
   resolved "https://registry.yarnpkg.com/std-env/-/std-env-3.7.0.tgz#c9f7386ced6ecf13360b6c6c55b8aaa4ef7481d2"
   integrity sha512-JPbdCEQLj1w5GilpiHAx3qJvFndqybBysA3qUOnznweH4QbNYUsW/ea8QzSrnh0vNsezMMw5bcVool8lM0gwzg==
@@ -1213,30 +1262,32 @@ strip-final-newline@^3.0.0:
   resolved "https://registry.yarnpkg.com/strip-final-newline/-/strip-final-newline-3.0.0.tgz#52894c313fbff318835280aed60ff71ebf12b8fd"
   integrity sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==
 
+strip-literal@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/strip-literal/-/strip-literal-2.1.0.tgz#6d82ade5e2e74f5c7e8739b6c84692bd65f0bd2a"
+  integrity sha512-Op+UycaUt/8FbN/Z2TWPBLge3jWrP3xj10f3fnYxf052bKuS3EKs1ZQcVGjnEMdsNVAM+plXRdmjrZ/KgG3Skw==
+  dependencies:
+    js-tokens "^9.0.0"
+
 supports-preserve-symlinks-flag@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
 
-tinybench@^2.8.0:
+tinybench@^2.5.1:
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/tinybench/-/tinybench-2.9.0.tgz#103c9f8ba6d7237a47ab6dd1dcff77251863426b"
   integrity sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==
 
-tinypool@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/tinypool/-/tinypool-1.0.0.tgz#a68965218e04f4ad9de037d2a1cd63cda9afb238"
-  integrity sha512-KIKExllK7jp3uvrNtvRBYBWBOAXSX8ZvoaD8T+7KB/QHIuoJW3Pmr60zucywjAlMb5TeXUkcs/MWeWLu0qvuAQ==
+tinypool@^0.8.3:
+  version "0.8.4"
+  resolved "https://registry.yarnpkg.com/tinypool/-/tinypool-0.8.4.tgz#e217fe1270d941b39e98c625dcecebb1408c9aa8"
+  integrity sha512-i11VH5gS6IFeLY3gMBQ00/MmLncVP7JLXOw1vlgkytLmJK7QnEr7NXf0LBdxfmNPAeyetukOk0bOYrJrFGjYJQ==
 
-tinyrainbow@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/tinyrainbow/-/tinyrainbow-1.2.0.tgz#5c57d2fc0fb3d1afd78465c33ca885d04f02abb5"
-  integrity sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==
-
-tinyspy@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/tinyspy/-/tinyspy-3.0.0.tgz#cb61644f2713cd84dee184863f4642e06ddf0585"
-  integrity sha512-q5nmENpTHgiPVd1cJDDc9cVoYN5x4vCvwT3FMilvKPKneCBZAxn2YWQjDF0UMcE9k0Cay1gBiDfTMU0g+mPMQA==
+tinyspy@^2.2.0:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/tinyspy/-/tinyspy-2.2.1.tgz#117b2342f1f38a0dbdcc73a50a454883adf861d1"
+  integrity sha512-KYad6Vy5VDWV4GH3fjpseMQ/XU2BhIYP7Vzd0LG44qRWm/Yt2WCOTicFdvmgo6gWaqooMQCawTtILVQJupKu7A==
 
 to-regex-range@^5.0.1:
   version "5.0.1"
@@ -1249,6 +1300,11 @@ tslib@^2.2.0:
   version "2.6.3"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.3.tgz#0438f810ad7a9edcde7a241c3d80db693c8cbfe0"
   integrity sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==
+
+type-detect@^4.0.0, type-detect@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.1.0.tgz#deb2453e8f08dcae7ae98c626b13dddb0155906c"
+  integrity sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==
 
 typescript@^5.5.4:
   version "5.5.4"
@@ -1284,15 +1340,15 @@ undici@^5.28.4:
     pathe "^1.1.2"
     ufo "^1.5.3"
 
-vite-node@2.0.5:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/vite-node/-/vite-node-2.0.5.tgz#36d909188fc6e3aba3da5fc095b3637d0d18e27b"
-  integrity sha512-LdsW4pxj0Ot69FAoXZ1yTnA9bjGohr2yNBU7QKRxpz8ITSkhuDl6h3zS/tvgz4qrNjeRnvrWeXQ8ZF7Um4W00Q==
+vite-node@1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/vite-node/-/vite-node-1.5.0.tgz#7f74dadfecb15bca016c5ce5ef85e5cc4b82abf2"
+  integrity sha512-tV8h6gMj6vPzVCa7l+VGq9lwoJjW8Y79vst8QZZGiuRAfijU+EEWuc0kFpmndQrWhMMhet1jdSF+40KSZUqIIw==
   dependencies:
     cac "^6.7.14"
-    debug "^4.3.5"
-    pathe "^1.1.2"
-    tinyrainbow "^1.2.0"
+    debug "^4.3.4"
+    pathe "^1.1.1"
+    picocolors "^1.0.0"
     vite "^5.0.0"
 
 vite@^5.0.0:
@@ -1306,30 +1362,31 @@ vite@^5.0.0:
   optionalDependencies:
     fsevents "~2.3.3"
 
-vitest@2.0.5:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/vitest/-/vitest-2.0.5.tgz#2f15a532704a7181528e399cc5b754c7f335fd62"
-  integrity sha512-8GUxONfauuIdeSl5f9GTgVEpg5BTOlplET4WEDaeY2QBiN8wSm68vxN/tb5z405OwppfoCavnwXafiaYBC/xOA==
+vitest@1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/vitest/-/vitest-1.5.0.tgz#6ebb396bd358650011a9c96c18fa614b668365c1"
+  integrity sha512-d8UKgR0m2kjdxDWX6911uwxout6GHS0XaGH1cksSIVVG8kRlE7G7aBw7myKQCvDI5dT4j7ZMa+l706BIORMDLw==
   dependencies:
-    "@ampproject/remapping" "^2.3.0"
-    "@vitest/expect" "2.0.5"
-    "@vitest/pretty-format" "^2.0.5"
-    "@vitest/runner" "2.0.5"
-    "@vitest/snapshot" "2.0.5"
-    "@vitest/spy" "2.0.5"
-    "@vitest/utils" "2.0.5"
-    chai "^5.1.1"
-    debug "^4.3.5"
+    "@vitest/expect" "1.5.0"
+    "@vitest/runner" "1.5.0"
+    "@vitest/snapshot" "1.5.0"
+    "@vitest/spy" "1.5.0"
+    "@vitest/utils" "1.5.0"
+    acorn-walk "^8.3.2"
+    chai "^4.3.10"
+    debug "^4.3.4"
     execa "^8.0.1"
-    magic-string "^0.30.10"
-    pathe "^1.1.2"
-    std-env "^3.7.0"
-    tinybench "^2.8.0"
-    tinypool "^1.0.0"
-    tinyrainbow "^1.2.0"
+    local-pkg "^0.5.0"
+    magic-string "^0.30.5"
+    pathe "^1.1.1"
+    picocolors "^1.0.0"
+    std-env "^3.5.0"
+    strip-literal "^2.0.0"
+    tinybench "^2.5.1"
+    tinypool "^0.8.3"
     vite "^5.0.0"
-    vite-node "2.0.5"
-    why-is-node-running "^2.3.0"
+    vite-node "1.5.0"
+    why-is-node-running "^2.2.2"
 
 which@^2.0.1:
   version "2.0.2"
@@ -1338,7 +1395,7 @@ which@^2.0.1:
   dependencies:
     isexe "^2.0.0"
 
-why-is-node-running@^2.3.0:
+why-is-node-running@^2.2.2:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/why-is-node-running/-/why-is-node-running-2.3.0.tgz#a3f69a97107f494b3cdc3bdddd883a7d65cebf04"
   integrity sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==
@@ -1427,6 +1484,11 @@ xxhash-wasm@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/xxhash-wasm/-/xxhash-wasm-1.0.2.tgz#ecc0f813219b727af4d5f3958ca6becee2f2f1ff"
   integrity sha512-ibF0Or+FivM9lNrg+HGJfVX8WJqgo+kCLDc4vx6xMeTce7Aj+DLttKbxxRR/gNLSAelRc1omAPlJ77N/Jem07A==
+
+yocto-queue@^1.0.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-1.1.1.tgz#fef65ce3ac9f8a32ceac5a634f74e17e5b232110"
+  integrity sha512-b4JR1PFR10y1mKjhHY9LaGo6tmrgjit7hxVIeAmyMw3jegXR4dhYqLaQF5zMXZxY7tLpMyJeLjr1C4rLmkVe8g==
 
 youch@^3.2.2:
   version "3.3.3"


### PR DESCRIPTION
Commit offsets patch 用于在源文档发生更改时动态修正 offset，该功能的算法大致如下：
1. 检测文档更改，分为插入（insert）、删除（delete）、替换（replace）三种更改模式
2. 对于这三种模式，分别对文档段落（diff.len）和文档段落之间的空行（diff.diff）计算位置
3. 对上述两种更改，按照“diff 完全包含 offset”、“offset 完全包含 diff”、“diff 左半边在 offset 内，右半边在 offset 外”、“diff 右半边在 offset 内，左半边在 offset 外”四种方案进行位置修正
4. 特殊的，引入 `pseudoOffsetsDiffArr.beforeEverything` 作为所有 offset 前的伪占位符来辅助计算（不需要 `afterEverything`，因为 所有 offset 后发生的更改不会影响这些 offset 的相对位置）
5. 特殊的，对于跨段 replace，无法计算哪些部分属于哪些段落，因此直接讲这部分评论全部删除掉

该 pr 还同时支持了 path 更改，用于在迁移页面路径时使用。