### PR TITLE
fix: show administration actions

### DIFF
--- a/frontend/lib/main.ts
+++ b/frontend/lib/main.ts
@@ -700,7 +700,7 @@ const _renderComments = (comments: Comment[]) => {
         ".comment_header .comment_actions",
       ) as HTMLDivElement;
 
-      let shouldShowAdministrationActions = false;
+      let shouldShowAdministrationActions = true;
       let shouldShowCommonActions = true;
 
       if (


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/e4a92506-304c-4a6d-ac39-0e2241c1c19c)

变量初始值写反了，导致现在用户没法删除自己的评论