### PR TITLE
docs: update build docs and bump to v0.5.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,20 @@ Enjoy!
 
 要进行开发环境调试，请运行 `yarn dev`。
 
+您需要在 `cloudflare-workers/.dev.vars` 文件中配置相关环境变量：
+
+```
+ADMINISTRATOR_SECRET="xxx"
+TELEGRAM_BOT_TOKEN="111:222-333"
+TELEGRAM_CHAT_ID="401081860"
+GITHUB_APP_CLIENT_ID="Iv1.05d621294f305efc"
+GITHUB_APP_CLIENT_SECRET="111111111111111111111111111111111"
+OAUTH_JWT_SECRET="111111111111111111111111111"
+GITHUB_ORG_ADMINISTRATOR_TEAM="OI-wiki/feedback-sys-mod"
+```
+
+关于 GitHub App 的配置，需要创建一个 GitHub App，并在 `GITHUB_APP_CLIENT_ID`, `GITHUB_APP_CLIENT_SECRET` 中填入对应的值。并且在 GitHub App 的设置中，把 `callback URL` 设置为 `http://localhost:8787/oauth/callback`。
+
 要进行单元测试，请运行 `yarn test`。
 
 ### frontend

--- a/cloudflare-workers/package.json
+++ b/cloudflare-workers/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cloudflare-workers",
-	"version": "0.5.6",
+	"version": "0.5.7",
 	"private": true,
 	"scripts": {
 		"deploy": "wrangler deploy",

--- a/cloudflare-workers/wrangler.toml
+++ b/cloudflare-workers/wrangler.toml
@@ -10,7 +10,7 @@ mode = "smart"
 [[d1_databases]]
 binding = "DB"
 database_name = "comments"
-database_id = "eba686c4-352d-4a8d-8f4e-fb3801166973"
+database_id = "146d0342-8df8-426d-b2e1-25f366251b40"
 
 # Automatically place your workloads in an optimal location to minimize latency.
 # If you are running back-end logic in a Worker, running it closer to your back-end infrastructure

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "oiwiki-feedback-sys-frontend",
   "private": false,
-  "version": "0.5.6",
+  "version": "0.5.7",
   "license": "Apache-2.0",
   "type": "module",
   "files": [

--- a/python-markdown-extension/pyproject.toml
+++ b/python-markdown-extension/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "python_markdown_document_offsets_injection_extension"
-version = "0.5.6"
+version = "0.5.7"
 description = "A Python-Markdown compiler plugin that put markdown words offset to the output HTML."
 authors = [{ name = "HikariLan", email = "hikarilan@minecraft.kim" }]
 license = { text = "Apache-2.0" }


### PR DESCRIPTION
更新日志：

1. 修复了无法复制有评论的文段的问题
2. 修复了展开评论时没有动画的问题
3. 优化了按钮的hover区域
4. 修复了当用户重新登录时，其头像和用户 profile 未被更新的问题
5. 优化了管理菜单的操作逻辑：当悬浮到整个评论的时候即可显示管理菜单，而不是必须悬浮到 header 上
6. 用户头像不再可以选中