### PR TITLE
chore: bump to v0.5.8

### DIFF
--- a/cloudflare-workers/package.json
+++ b/cloudflare-workers/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cloudflare-workers",
-	"version": "0.5.7",
+	"version": "0.5.8",
 	"private": true,
 	"scripts": {
 		"deploy": "wrangler deploy",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "oiwiki-feedback-sys-frontend",
   "private": false,
-  "version": "0.5.7",
+  "version": "0.5.8",
   "license": "Apache-2.0",
   "type": "module",
   "files": [

--- a/python-markdown-extension/pyproject.toml
+++ b/python-markdown-extension/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "python_markdown_document_offsets_injection_extension"
-version = "0.5.7"
+version = "0.5.8"
 description = "A Python-Markdown compiler plugin that put markdown words offset to the output HTML."
 authors = [{ name = "HikariLan", email = "hikarilan@minecraft.kim" }]
 license = { text = "Apache-2.0" }


### PR DESCRIPTION
更新日志：

1. 启用了自定义域名和o11y功能
2. 在后端的 / 上添加了一个 welcome page
3. 修复了焦点打架没修好的问题