### PR TITLE
fix: pending for submit & modify submit is not correctly displayed 

### DIFF
--- a/frontend/lib/dom/comment.ts
+++ b/frontend/lib/dom/comment.ts
@@ -243,7 +243,7 @@ export const submitComment = async ({
       pending: true,
     });
   }
-
+  await openCommentsPanel();
   const resp = await res;
 
   if (!resp.ok) {
@@ -263,7 +263,7 @@ export const submitComment = async ({
   updateAvailableComments();
 };
 
-export const _modifyComment = async ({
+export const modifyComment = async ({
   id,
   comment,
 }: {
@@ -290,6 +290,7 @@ export const _modifyComment = async ({
     );
   }
 
+  await openCommentsPanel();
   const resp = await res;
 
   if (!resp.ok) {
@@ -714,7 +715,6 @@ export const renderComments = async (comments: Comment[]) => {
             }
 
             notification.textContent = "";
-            await openCommentsPanel();
             const newSubmitButton = commentsPanel.querySelector(
               "[data-review-selected] button[data-action='submit']",
             ) as HTMLButtonElement;
@@ -805,10 +805,9 @@ export const renderComments = async (comments: Comment[]) => {
           case "modify_submit": {
             const id = container.dataset.modifingId;
             if (id == undefined) return;
-            await openCommentsPanel();
 
             try {
-              await _modifyComment({
+              await modifyComment({
                 id: parseInt(id),
                 comment: textarea.value,
               });

--- a/frontend/lib/dom/comment.ts
+++ b/frontend/lib/dom/comment.ts
@@ -196,9 +196,11 @@ export const closeCommentsPanel = () => {
 export const submitComment = async ({
   offsets,
   content,
+  onPendingFulfilled,
 }: {
   offsets: [number, number];
   content: string;
+  onPendingFulfilled?: () => Promise<void>;
 }) => {
   const commitHash = sessionStorage.getItem("commitHash");
   if (!commitHash) {
@@ -243,7 +245,7 @@ export const submitComment = async ({
       pending: true,
     });
   }
-  await openCommentsPanel();
+  await onPendingFulfilled?.();
   const resp = await res;
 
   if (!resp.ok) {
@@ -266,9 +268,11 @@ export const submitComment = async ({
 export const modifyComment = async ({
   id,
   comment,
+  onPendingFulfilled,
 }: {
   id: number;
   comment: string;
+  onPendingFulfilled?: () => Promise<void>;
 }) => {
   const res = fetch(
     `${apiEndpoint}comment/${encodeURIComponent(new URL(window.location.href).pathname)}/id/${id}`,
@@ -290,7 +294,7 @@ export const modifyComment = async ({
     );
   }
 
-  await openCommentsPanel();
+  await onPendingFulfilled?.();
   const resp = await res;
 
   if (!resp.ok) {
@@ -730,6 +734,9 @@ export const renderComments = async (comments: Comment[]) => {
                   parseInt(selectedOffset!.dataset.originalDocumentEnd!),
                 ],
                 content: textarea.value,
+                onPendingFulfilled: async () => {
+                  await openCommentsPanel();
+                },
               });
 
               textarea.value = "";
@@ -810,6 +817,9 @@ export const renderComments = async (comments: Comment[]) => {
               await modifyComment({
                 id: parseInt(id),
                 comment: textarea.value,
+                onPendingFulfilled: async () => {
+                  await openCommentsPanel();
+                },
               });
 
               textarea.value = "";


### PR DESCRIPTION
> mgt, [2024/9/29 23:09]
> 这里期望的事件发生顺序是这样的：
> 1. 提交网络请求
> 2. 将尚未提交的评论放进cache里面
> 3. 重新渲染评论（为了显示刚刚放进去的那个）
> 4. 等待网络请求返回
> 5. 重新渲染评论
> 
> mgt, [2024/9/29 23:09]
> 之前这里用了两个race执行的promise，分别是
> 1 -> 2 -> 4 -> 5 和 3